### PR TITLE
Fix BitcoinProcessor.ts getUnspentCoins function

### DIFF
--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -282,40 +282,40 @@ export default class BitcoinProcessor {
     }
 
     const transactions = JSON.parse(responseData) as Array<any>;
-    
+
     // Generate all transaction outputs (txos)
-    let txos: {[txid: string] : any; } = {};  // transaction outputs dictionary
-    for (let i=0; i < transactions.length; i++) {
+    let txos: {[txid: string]: any; } = {};  // transaction outputs dictionary
+    for (let i = 0; i < transactions.length; i++) {
       let txid = transactions[i].hash;
       let confirmations = transactions[i].confirmations;
       let outputs = transactions[i].outputs;
-      for (let j=0; j < outputs.length; j++) {
+      for (let j = 0; j < outputs.length; j++) {
         if (outputs[j].address === address) {
-          txos[txid] = {"txid": txid, "vout": j, "address": outputs[j].address, "account": "",
-          "script": outputs[j].script, "amount": outputs[j].value * 0.00000001,
-          "confirmations": confirmations, "spendable": true, "solvable": true};
-        };
-      };
-    };
-    
+          txos[txid] = {'txid': txid, 'vout': j, 'address': outputs[j].address, 'account': '',
+            'script': outputs[j].script, 'amount': outputs[j].value * 0.00000001,
+            'confirmations': confirmations, 'spendable': true, 'solvable': true};
+        }
+      }
+    }
+
     // Flag all spent transaction outputs (set txo.spendable to false)
-    for (let i=0; i < transactions.length; i++) {
+    for (let i = 0; i < transactions.length; i++) {
       let inputs = transactions[i].inputs;
-      for (let j=0; j < inputs.length; j++) {
+      for (let j = 0; j < inputs.length; j++) {
         if ((inputs[j].prevout.hash in txos)) {
           txos[inputs[j].prevout.hash].spendable = false;
-        };
-      };
-    };
-    
+        }
+      }
+    }
+
     // Retrieve all unspent transaction outputs (tx.spendable === true)
     let utxos = [];
     for (let txid in txos) {
       if (txos[txid].spendable === true) {
         utxos.push(txos[txid]);
-      };
-    };
-    
+      }
+    }
+
     // Generate bitcore UnspentOutput array from utxos array
     const unspentCoins = utxos.map((coin) => {
       return new Transaction.UnspentOutput({
@@ -326,9 +326,9 @@ export default class BitcoinProcessor {
         amount: coin.amount
       });
     });
-    
+
     console.info(`Returning ${unspentCoins.length} coins`);
-    
+
     return unspentCoins;
   }
 

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -267,7 +267,7 @@ export default class BitcoinProcessor {
    * @param address Bitcoin address to get coins for
    */
   private async getUnspentCoins (address: Address): Promise<Transaction.UnspentOutput[]> {
-    
+
     // Retrieve all transactions by addressToSearch via BCoin Node API /tx/address/$address endpoint
     const addressToSearch = address.toString();
     console.info(`Getting unspent coins for ${addressToSearch}`);

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -267,6 +267,8 @@ export default class BitcoinProcessor {
    * @param address Bitcoin address to get coins for
    */
   private async getUnspentCoins (address: Address): Promise<Transaction.UnspentOutput[]> {
+    
+    // Retrieve all transactions by addressToSearch via BCoin Node API /tx/address/$address endpoint
     const addressToSearch = address.toString();
     console.info(`Getting unspent coins for ${addressToSearch}`);
     const requestPath = `/tx/address/${addressToSearch}`;
@@ -290,7 +292,7 @@ export default class BitcoinProcessor {
       let confirmations = transactions[i].confirmations;
       let outputs = transactions[i].outputs;
       for (let j = 0; j < outputs.length; j++) {
-        if (outputs[j].address === address) {
+        if (outputs[j].address === addressToSearch) {
           txos[txid] = {'txid': txid, 'vout': j, 'address': outputs[j].address, 'account': '',
             'script': outputs[j].script, 'amount': outputs[j].value * 0.00000001,
             'confirmations': confirmations, 'spendable': true, 'solvable': true};

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -291,9 +291,9 @@ export default class BitcoinProcessor {
       let outputs = transactions[i].outputs;
       for (let j=0; j < outputs.length; j++) {
         if (outputs[j].address === address) {
-              txos[txid] = {"txid": txid, "vout": j, "address": outputs[j].address, "account": "",
-              "script": outputs[j].script, "amount": outputs[j].value * 0.00000001,
-              "confirmations": confirmations, "spendable": true, "solvable": true};
+          txos[txid] = {"txid": txid, "vout": j, "address": outputs[j].address, "account": "",
+          "script": outputs[j].script, "amount": outputs[j].value * 0.00000001,
+          "confirmations": confirmations, "spendable": true, "solvable": true};
         };
       };
     };
@@ -303,7 +303,7 @@ export default class BitcoinProcessor {
       let inputs = transactions[i].inputs;
       for (let j=0; j < inputs.length; j++) {
         if ((inputs[j].prevout.hash in txos)) {
-            txos[inputs[j].prevout.hash].spendable = false;
+          txos[inputs[j].prevout.hash].spendable = false;
         };
       };
     };
@@ -312,7 +312,7 @@ export default class BitcoinProcessor {
     let utxos = [];
     for (let txid in txos) {
       if (txos[txid].spendable === true) {
-          utxos.push(txos[txid]);
+        utxos.push(txos[txid]);
       };
     };
     

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -269,7 +269,7 @@ export default class BitcoinProcessor {
   private async getUnspentCoins (address: Address): Promise<Transaction.UnspentOutput[]> {
     const addressToSearch = address.toString();
     console.info(`Getting unspent coins for ${addressToSearch}`);
-    const requestPath = `/coin/address/${addressToSearch}`;
+    const requestPath = `/tx/address/${addressToSearch}`;
 
     const fullPath = new URL(requestPath, this.bitcoinPeerUri);
     const response = await this.fetchWithRetry(fullPath.toString());
@@ -281,18 +281,55 @@ export default class BitcoinProcessor {
       throw error;
     }
 
-    const responseJson = JSON.parse(responseData) as Array<any>;
-    const unspentTransactions = responseJson.map((coin) => {
-      return new Transaction.UnspentOutput({
-        txid: coin.hash,
-        vout: coin.index,
-        address: coin.address,
-        script: coin.script,
-        amount: coin.value * 0.00000001 // Satoshi amount
-      });
+    const transactions = JSON.parse(responseData) as Array<any>;
+    
+    // Generate all transaction outputs (txos)
+    let txos: {[txid: string] : any; };  // transaction outputs dictionary
+    for (let i=0; i < transactions.length; i++) {
+        let txid = transactions[i].hash;
+        let confirmations = transactions[i].confirmations;
+        let outputs = transactions[i].outputs;
+        for (let j=0; j < outputs.length; j++) {
+            if (outputs[j].address == address) {
+                txos[txid] = {"txid": txid, "vout": j, "address": outputs[j].address, "account": "",
+                "script": outputs[j].script, "amount": outputs[j].value * 0.00000001,
+                "confirmations": confirmations, "spendable": true, "solvable": true};
+            };
+        };
+    };
+    
+    // Flag all spent transaction outputs (set txo.spendable to false)
+    for (let i=0; i < transactions.length; i++) {
+        let inputs = transactions[i].inputs;
+        for (let j=0; j < inputs.length; j++) {
+            if ((inputs[j].prevout.hash in txos)) {
+                txos[inputs[j].prevout.hash].spendable = false;
+            };
+        };
+    };
+    
+    // Retrieve all unspent transaction outputs (tx.spendable === true)
+    let utxos = [];
+    for (let txid in txos) {
+        if (txos[txid].spendable === true) {
+            utxos.push(txos[txid]);
+        };
+    };
+    
+    // Generate bitcore UnspentOutput array from utxos array
+    const unspentCoins = utxos.map((coin) => {
+        return new Transaction.UnspentOutput({
+            txid: coin.txid,
+            vout: coin.vout,
+            address: coin.address,
+            script: coin.script,
+            amount: coin.amount
+        });
     });
-    console.info(`Returning ${unspentTransactions.length} coins`);
-    return unspentTransactions;
+    
+    console.info(`Returning ${unspentCoins.length} coins`);
+    
+    return unspentCoins;
   }
 
   /**
@@ -301,7 +338,7 @@ export default class BitcoinProcessor {
    */
   private async broadcastTransaction (transaction: Transaction): Promise<boolean> {
     const rawTransaction = transaction.serialize();
-    console.info(`Boradcasting transaction ${transaction.id}`);
+    console.info(`Broadcasting transaction ${transaction.id}`);
     const request = JSON.stringify({
       tx: rawTransaction
     });

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -286,45 +286,45 @@ export default class BitcoinProcessor {
     // Generate all transaction outputs (txos)
     let txos: {[txid: string] : any; } = {};  // transaction outputs dictionary
     for (let i=0; i < transactions.length; i++) {
-        let txid = transactions[i].hash;
-        let confirmations = transactions[i].confirmations;
-        let outputs = transactions[i].outputs;
-        for (let j=0; j < outputs.length; j++) {
-            if (outputs[j].address == address) {
-                txos[txid] = {"txid": txid, "vout": j, "address": outputs[j].address, "account": "",
-                "script": outputs[j].script, "amount": outputs[j].value * 0.00000001,
-                "confirmations": confirmations, "spendable": true, "solvable": true};
-            };
+      let txid = transactions[i].hash;
+      let confirmations = transactions[i].confirmations;
+      let outputs = transactions[i].outputs;
+      for (let j=0; j < outputs.length; j++) {
+        if (outputs[j].address === address) {
+              txos[txid] = {"txid": txid, "vout": j, "address": outputs[j].address, "account": "",
+              "script": outputs[j].script, "amount": outputs[j].value * 0.00000001,
+              "confirmations": confirmations, "spendable": true, "solvable": true};
         };
+      };
     };
     
     // Flag all spent transaction outputs (set txo.spendable to false)
     for (let i=0; i < transactions.length; i++) {
-        let inputs = transactions[i].inputs;
-        for (let j=0; j < inputs.length; j++) {
-            if ((inputs[j].prevout.hash in txos)) {
-                txos[inputs[j].prevout.hash].spendable = false;
-            };
+      let inputs = transactions[i].inputs;
+      for (let j=0; j < inputs.length; j++) {
+        if ((inputs[j].prevout.hash in txos)) {
+            txos[inputs[j].prevout.hash].spendable = false;
         };
+      };
     };
     
     // Retrieve all unspent transaction outputs (tx.spendable === true)
     let utxos = [];
     for (let txid in txos) {
-        if (txos[txid].spendable === true) {
-            utxos.push(txos[txid]);
-        };
+      if (txos[txid].spendable === true) {
+          utxos.push(txos[txid]);
+      };
     };
     
     // Generate bitcore UnspentOutput array from utxos array
     const unspentCoins = utxos.map((coin) => {
-        return new Transaction.UnspentOutput({
-            txid: coin.txid,
-            vout: coin.vout,
-            address: coin.address,
-            script: coin.script,
-            amount: coin.amount
-        });
+      return new Transaction.UnspentOutput({
+        txid: coin.txid,
+        vout: coin.vout,
+        address: coin.address,
+        script: coin.script,
+        amount: coin.amount
+      });
     });
     
     console.info(`Returning ${unspentCoins.length} coins`);

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -284,7 +284,7 @@ export default class BitcoinProcessor {
     const transactions = JSON.parse(responseData) as Array<any>;
     
     // Generate all transaction outputs (txos)
-    let txos: {[txid: string] : any; };  // transaction outputs dictionary
+    let txos: {[txid: string] : any; } = {};  // transaction outputs dictionary
     for (let i=0; i < transactions.length; i++) {
         let txid = transactions[i].hash;
         let confirmations = transactions[i].confirmations;

--- a/tests/bitcoin/BitcoinProcessor.spec.ts
+++ b/tests/bitcoin/BitcoinProcessor.spec.ts
@@ -412,8 +412,8 @@ describe('BitcoinProcessor', () => {
       const coin = generateUnspentCoin(0);
       const getCoinsSpy = spyOn(bitcoinProcessor, 'getUnspentCoins' as any).and.returnValue(Promise.resolve([
         new Transaction.UnspentOutput({
-          txid: coin.txid,
-          vout: coin.vout,
+          txid: coin.txId,
+          vout: coin.outputIndex,
           address: coin.address,
           script: coin.script,
           amount: 0
@@ -469,11 +469,11 @@ describe('BitcoinProcessor', () => {
       });
       const readStreamSpy = spyOn(ReadableStream, 'readAll').and.returnValue(Promise.resolve(JSON.stringify([
         {
-          "hash": coin.txid,
+          "hash": coin.txId,
           "inputs": [],
           "outputs": [
             {
-              "value": coin.amount * 100000000,
+              "value": coin.satoshis,
               "script": coin.script,
               "address": coin.address
             }
@@ -485,7 +485,7 @@ describe('BitcoinProcessor', () => {
       expect(retryFetchSpy).toHaveBeenCalled();
       expect(readStreamSpy).toHaveBeenCalled();
       expect(actual[0].address).toEqual(coin.address);
-      expect(actual[0].txid).toEqual(coin.txid);
+      expect(actual[0].txId).toEqual(coin.txId);
       done();
     });
 

--- a/tests/bitcoin/BitcoinProcessor.spec.ts
+++ b/tests/bitcoin/BitcoinProcessor.spec.ts
@@ -469,16 +469,16 @@ describe('BitcoinProcessor', () => {
       });
       const readStreamSpy = spyOn(ReadableStream, 'readAll').and.returnValue(Promise.resolve(JSON.stringify([
         {
-          "hash": coin.txId,
-          "inputs": [],
-          "outputs": [
+          hash: coin.txId,
+          inputs: [],
+          outputs: [
             {
-              "value": coin.satoshis,
-              "script": coin.script,
-              "address": coin.address
+              value: coin.satoshis,
+              script: coin.script,
+              address: coin.address
             }
           ],
-          "confirmations": 0
+          confirmations: 0
         }
       ])));
       const actual = await bitcoinProcessor['getUnspentCoins'](coin.address);

--- a/tests/bitcoin/BitcoinProcessor.spec.ts
+++ b/tests/bitcoin/BitcoinProcessor.spec.ts
@@ -462,7 +462,7 @@ describe('BitcoinProcessor', () => {
     it('should query for unspent output coins given an address', async (done) => {
       const coin = generateUnspentCoin(1);
       retryFetchSpy.and.callFake((uri: string) => {
-        expect(uri).toContain('/coin/address/');
+        expect(uri).toContain('/tx/address/');
         return {
           status: httpStatus.OK
         };
@@ -487,7 +487,7 @@ describe('BitcoinProcessor', () => {
     it('should throw if the request failed', async (done) => {
       const coin = generateUnspentCoin(0);
       retryFetchSpy.and.callFake((uri: string) => {
-        expect(uri).toContain('/coin/address/');
+        expect(uri).toContain('/tx/address/');
         return {
           status: httpStatus.BAD_REQUEST
         };
@@ -507,7 +507,7 @@ describe('BitcoinProcessor', () => {
     it('should return empty if no coins were found', async (done) => {
       const coin = generateUnspentCoin(1);
       retryFetchSpy.and.callFake((uri: string) => {
-        expect(uri).toContain('/coin/address/');
+        expect(uri).toContain('/tx/address/');
         return {
           status: httpStatus.OK
         };

--- a/tests/bitcoin/BitcoinProcessor.spec.ts
+++ b/tests/bitcoin/BitcoinProcessor.spec.ts
@@ -412,8 +412,8 @@ describe('BitcoinProcessor', () => {
       const coin = generateUnspentCoin(0);
       const getCoinsSpy = spyOn(bitcoinProcessor, 'getUnspentCoins' as any).and.returnValue(Promise.resolve([
         new Transaction.UnspentOutput({
-          txid: coin.txId,
-          vout: coin.outputIndex,
+          txid: coin.txid,
+          vout: coin.vout,
           address: coin.address,
           script: coin.script,
           amount: 0
@@ -469,18 +469,23 @@ describe('BitcoinProcessor', () => {
       });
       const readStreamSpy = spyOn(ReadableStream, 'readAll').and.returnValue(Promise.resolve(JSON.stringify([
         {
-          hash: coin.txId,
-          index: coin.outputIndex,
-          address: coin.address,
-          script: coin.script,
-          value: coin.satoshis
+          "hash": coin.txid,
+          "inputs": [],
+          "outputs": [
+            {
+              "value": coin.amount * 100000000,
+              "script": coin.script,
+              "address": coin.address
+            }
+          ],
+          "confirmations": 0
         }
       ])));
       const actual = await bitcoinProcessor['getUnspentCoins'](coin.address);
       expect(retryFetchSpy).toHaveBeenCalled();
       expect(readStreamSpy).toHaveBeenCalled();
       expect(actual[0].address).toEqual(coin.address);
-      expect(actual[0].txId).toEqual(coin.txId);
+      expect(actual[0].txid).toEqual(coin.txid);
       done();
     });
 

--- a/tests/bitcoin/BitcoinProcessor.spec.ts
+++ b/tests/bitcoin/BitcoinProcessor.spec.ts
@@ -475,7 +475,7 @@ describe('BitcoinProcessor', () => {
             {
               value: coin.satoshis,
               script: coin.script,
-              address: coin.address
+              address: coin.address.toString()
             }
           ],
           confirmations: 0


### PR DESCRIPTION
1. Refactoring of the getUnspentCoins function in BitcoinProcessor.ts:
- Replace deprecated BCoin node API call `/coin/address/$address` by `/tx/address/$address` (refer to [BCoin changelog](https://github.com/bcoin-org/bcoin/blob/master/CHANGELOG.md) Node API changes section.
- Insert additional code to generate unspent transactions from all transaction outputs retrieved with the new API call.
This fix should solve [issue ](https://github.com/decentralized-identity/ion/issues/23).
2. Fixing typo in console.log text in BitcoinProcessor.ts
3. Updating BitcoinProcessor.spec.ts in line with changes in 1. 
