### PR TITLE
Issue #161 - Added caching of blockchain time + many code improvements.

### DIFF
--- a/lib/common/ErrorCode.ts
+++ b/lib/common/ErrorCode.ts
@@ -2,7 +2,9 @@
  * Error codes.
  */
 enum ErrorCode {
-  InvalidTransactionNumberOrTimeHash = 'invalid_transaction_number_or_time_hash'
+  InvalidTransactionNumberOrTimeHash = 'invalid_transaction_number_or_time_hash',
+  OperationExceedsMaximumSize = 'operation_exceeds_maximum_size',
+  QueueingMultipleOperationsPerDidNotAllowed = 'queueing_multiple_operations_per_did_not_allowed'
 }
 
 export default ErrorCode;

--- a/lib/core/BatchFile.ts
+++ b/lib/core/BatchFile.ts
@@ -75,15 +75,15 @@ export default class BatchFile {
 
       let operation;
       try {
-        operation = Operation.create(operationBuffer, resolvedTransaction, operationIndex);
+        operation = Operation.createAnchoredOperation(operationBuffer, resolvedTransaction, operationIndex);
       } catch (error) {
         console.info(`Unable to create an Operation object with '${operationBuffer}': ${error}`);
         throw error;
       }
 
       const didUniqueSuffixesInAnchorFile = anchorFile.didUniqueSuffixes[operationIndex];
-      if (operation.didUniqueSuffix! !== didUniqueSuffixesInAnchorFile) {
-        console.info(`Operation ${operationIndex}'s DID unique suffix '${operation.didUniqueSuffix!}' ` +
+      if (operation.didUniqueSuffix !== didUniqueSuffixesInAnchorFile) {
+        console.info(`Operation ${operationIndex}'s DID unique suffix '${operation.didUniqueSuffix}' ` +
                      `is not the same as '${didUniqueSuffixesInAnchorFile}' seen in anchor file.`);
       }
 

--- a/lib/core/MongoDbOperationStore.ts
+++ b/lib/core/MongoDbOperationStore.ts
@@ -110,7 +110,7 @@ export default class MongoDbOperationStore implements OperationStore {
    */
   private static convertToMongoOperation (operation: Operation): IMongoOperation {
     return {
-      didUniqueSuffix: operation.didUniqueSuffix!,
+      didUniqueSuffix: operation.didUniqueSuffix,
       operationBufferBsonBinary: new Binary(operation.operationBuffer),
       opIndex: operation.operationIndex!,
       transactionNumber: Long.fromNumber(operation.transactionNumber!),
@@ -127,7 +127,7 @@ export default class MongoDbOperationStore implements OperationStore {
    * hence the type 'any' for mongoOperation.
    */
   private static convertToOperation (mongoOperation: any): Operation {
-    return Operation.create(
+    return Operation.createAnchoredOperation(
       mongoOperation.operationBufferBsonBinary.buffer,
       {
         transactionNumber: mongoOperation.transactionNumber,

--- a/lib/core/Observer.ts
+++ b/lib/core/Observer.ts
@@ -61,7 +61,7 @@ export default class Observer {
   }
 
   /**
-   * The function that starts the periodic polling and processing of Sidetree operations.
+   * The method that starts the periodic polling and processing of Sidetree operations.
    */
   public async startPeriodicProcessing () {
     // Initialize the last known transaction before starting processing.
@@ -249,7 +249,7 @@ export default class Observer {
       // Get the protocol parameters
       const protocolParameters = ProtocolParameters.get(transaction.transactionTime);
 
-      console.info(`Downloading anchor file '${transaction.anchorFileHash}', max size limit ${protocolParameters.maxAnchorFileSizeInBytes}...`);
+      console.info(`Downloading anchor file '${transaction.anchorFileHash}', max size limit ${protocolParameters.maxAnchorFileSizeInBytes} bytes...`);
       const anchorFileFetchResult = await this.downloadManager.download(transaction.anchorFileHash, protocolParameters.maxAnchorFileSizeInBytes);
 
       // No thing to process if the file hash is invalid. No retry needed.
@@ -260,7 +260,7 @@ export default class Observer {
 
       // No thing to process if the file size exceeds protocol specified size limit, no retry needed either.
       if (anchorFileFetchResult.code === FetchResultCode.MaxSizeExceeded) {
-        console.info(`Anchor file '${transaction.anchorFileHash}' exceeded max size limit ${protocolParameters.maxAnchorFileSizeInBytes}.`);
+        console.info(`Anchor file '${transaction.anchorFileHash}' exceeded max size limit ${protocolParameters.maxAnchorFileSizeInBytes} bytes.`);
         return;
       }
 
@@ -277,7 +277,7 @@ export default class Observer {
         return;
       }
 
-      console.info(`Anchor file '${transaction.anchorFileHash}' of size ${anchorFileFetchResult.content!.length} downloaded.`);
+      console.info(`Anchor file '${transaction.anchorFileHash}' of size ${anchorFileFetchResult.content!.length} bytes downloaded.`);
       let anchorFile: IAnchorFile;
       try {
         anchorFile = AnchorFile.parseAndValidate(anchorFileFetchResult.content!);

--- a/src/core.ts
+++ b/src/core.ts
@@ -29,7 +29,7 @@ app.use(async (ctx, next) => {
 
 const router = new Router();
 router.post('/', async (ctx, _next) => {
-  const response = await sidetreeCore.requestHandler.handleOperationRequest(ctx.body);
+  const response = sidetreeCore.requestHandler.handleOperationRequest(ctx.body);
   setKoaResponse(response, ctx.response);
 });
 

--- a/tests/core/MongoDbOperationStore.spec.ts
+++ b/tests/core/MongoDbOperationStore.spec.ts
@@ -24,7 +24,7 @@ function constructAnchoredOperation (
     batchFileHash: 'unused'
   };
 
-  return Operation.create(opBuf, resolvedTransaction, operationIndex);
+  return Operation.createAnchoredOperation(opBuf, resolvedTransaction, operationIndex);
 }
 
 /**
@@ -113,7 +113,7 @@ async function createOperationStore (mongoDbConnectionString: string): Promise<O
 }
 
 async function createBatchOfUpdateOperations (createOperation: Operation, batchSize: number, privateKey: string): Promise<Operation[]> {
-  const didUniqueSuffix = createOperation.didUniqueSuffix!;
+  const didUniqueSuffix = createOperation.didUniqueSuffix;
   const batch = new Array<Operation>(createOperation);
   for (let i = 1; i < batchSize ; i++) {
     const previousOperation = batch[i - 1];
@@ -172,14 +172,14 @@ describe('MongoDbOperationStore', async () => {
   it('should get a put create operation', async () => {
     const operation = await constructAnchoredCreateOperation(publicKey, privateKey, 0, 0, 0);
     await operationStore.put([operation]);
-    const returnedOperations = Array.from(await operationStore.get(operation.didUniqueSuffix!));
+    const returnedOperations = Array.from(await operationStore.get(operation.didUniqueSuffix));
     checkEqualArray([operation], returnedOperations);
   });
 
   it('should get a put update operation', async () => {
     // Use a create operation to generate a DID
     const createOperation = await constructAnchoredCreateOperation(publicKey, privateKey, 0, 0, 0);
-    const didUniqueSuffix = createOperation.didUniqueSuffix!;
+    const didUniqueSuffix = createOperation.didUniqueSuffix;
     const createVersion = createOperation.getOperationHash();
     const updateOperation = await constructAnchoredUpdateOperation(privateKey, didUniqueSuffix, createVersion, 1, 1, 0, 1);
     await operationStore.put([updateOperation]);
@@ -190,7 +190,7 @@ describe('MongoDbOperationStore', async () => {
   it('should ignore duplicate updates', async () => {
     // Use a create operation to generate a DID
     const createOperation = await constructAnchoredCreateOperation(publicKey, privateKey, 0, 0, 0);
-    const didUniqueSuffix = createOperation.didUniqueSuffix!;
+    const didUniqueSuffix = createOperation.didUniqueSuffix;
     const createVersion = createOperation.getOperationHash();
     const updateOperation = await constructAnchoredUpdateOperation(privateKey, didUniqueSuffix, createVersion, 1, 1, 0, 1);
     await operationStore.put([updateOperation]);
@@ -203,7 +203,7 @@ describe('MongoDbOperationStore', async () => {
   it('should get all operations in a batch put', async () => {
     // Use a create operation to generate a DID
     const createOperation = await constructAnchoredCreateOperation(publicKey, privateKey, 0, 0, 0);
-    const didUniqueSuffix = createOperation.didUniqueSuffix!;
+    const didUniqueSuffix = createOperation.didUniqueSuffix;
 
     const batchSize = 10;
     const batch = await createBatchOfUpdateOperations(createOperation, batchSize, privateKey);
@@ -216,7 +216,7 @@ describe('MongoDbOperationStore', async () => {
   it('should get all operations in a batch put with duplicates', async () => {
     // Use a create operation to generate a DID
     const createOperation = await constructAnchoredCreateOperation(publicKey, privateKey, 0, 0, 0);
-    const didUniqueSuffix = createOperation.didUniqueSuffix!;
+    const didUniqueSuffix = createOperation.didUniqueSuffix;
 
     const batchSize = 10;
     const batch = await createBatchOfUpdateOperations(createOperation, batchSize, privateKey);
@@ -231,7 +231,7 @@ describe('MongoDbOperationStore', async () => {
   it('should delete all', async () => {
     // Use a create operation to generate a DID
     const createOperation = await constructAnchoredCreateOperation(publicKey, privateKey, 0, 0, 0);
-    const didUniqueSuffix = createOperation.didUniqueSuffix!;
+    const didUniqueSuffix = createOperation.didUniqueSuffix;
 
     const batchSize = 10;
     const batch = await createBatchOfUpdateOperations(createOperation, batchSize, privateKey);
@@ -248,7 +248,7 @@ describe('MongoDbOperationStore', async () => {
   it('should delete operations with timestamp filter', async () => {
     // Use a create operation to generate a DID
     const createOperation = await constructAnchoredCreateOperation(publicKey, privateKey, 0, 0, 0);
-    const didUniqueSuffix = createOperation.didUniqueSuffix!;
+    const didUniqueSuffix = createOperation.didUniqueSuffix;
 
     const batchSize = 10;
     const batch = await createBatchOfUpdateOperations(createOperation, batchSize, privateKey);
@@ -266,7 +266,7 @@ describe('MongoDbOperationStore', async () => {
   it('should remember operations after stop/restart', async () => {
     // Use a create operation to generate a DID
     const createOperation = await constructAnchoredCreateOperation(publicKey, privateKey, 0, 0, 0);
-    const didUniqueSuffix = createOperation.didUniqueSuffix!;
+    const didUniqueSuffix = createOperation.didUniqueSuffix;
 
     const batchSize = 10;
     const batch = await createBatchOfUpdateOperations(createOperation, batchSize, privateKey);
@@ -285,7 +285,7 @@ describe('MongoDbOperationStore', async () => {
   it('should get all operations in transaction time order', async () => {
     // Use a create operation to generate a DID
     const createOperation = await constructAnchoredCreateOperation(publicKey, privateKey, 0, 0, 0);
-    const didUniqueSuffix = createOperation.didUniqueSuffix!;
+    const didUniqueSuffix = createOperation.didUniqueSuffix;
 
     const batchSize = 10;
     const batch = await createBatchOfUpdateOperations(createOperation, batchSize, privateKey);

--- a/tests/core/Operation.spec.ts
+++ b/tests/core/Operation.spec.ts
@@ -18,20 +18,20 @@ describe('Operation', async () => {
     createRequest.dummyProperty = '123';
     const requestWithUnknownProperty = Buffer.from(JSON.stringify(createRequest));
 
-    expect(() => { Operation.create(requestWithUnknownProperty); }).toThrowError();
+    expect(() => { Operation.createUnanchoredOperation(requestWithUnknownProperty, 1500000); }).toThrowError();
   });
 
   it('should throw error if more than one type of payload is found when parsing request.', async () => {
     createRequest.updatePayload = '123';
     const requestWithUnknownProperty = Buffer.from(JSON.stringify(createRequest));
 
-    expect(() => { Operation.create(requestWithUnknownProperty); }).toThrowError();
+    expect(() => { Operation.createUnanchoredOperation(requestWithUnknownProperty, 1500000); }).toThrowError();
   });
 
   it('should throw error if signature is not found when parsing request.', async () => {
     delete createRequest.signature;
     const requestWithUnknownProperty = Buffer.from(JSON.stringify(createRequest));
 
-    expect(() => { Operation.create(requestWithUnknownProperty); }).toThrowError();
+    expect(() => { Operation.createUnanchoredOperation(requestWithUnknownProperty, 1500000); }).toThrowError();
   });
 });

--- a/tests/core/OperationProcessor.spec.ts
+++ b/tests/core/OperationProcessor.spec.ts
@@ -32,7 +32,7 @@ async function addBatchFileOfOneOperationToCas (
     batchFileHash: batchFileAddress
   };
 
-  const op = Operation.create(opBuf, resolvedTransaction, operationIndex);
+  const op = Operation.createAnchoredOperation(opBuf, resolvedTransaction, operationIndex);
   return op;
 }
 

--- a/tests/mocks/MockBlockchain.ts
+++ b/tests/mocks/MockBlockchain.ts
@@ -48,10 +48,10 @@ export default class MockBlockchain implements Blockchain {
   }
 
   private latestTime?: IBlockchainTime = { time: 500000, hash: 'dummyHash' };
-  public async getLatestTime (): Promise<IBlockchainTime> {
+
+  public get approximateTime (): IBlockchainTime {
     return this.latestTime!;
   }
-
   /**
    * Hardcodes the latest time to be returned.
    */

--- a/tests/mocks/MockOperationStore.ts
+++ b/tests/mocks/MockOperationStore.ts
@@ -38,7 +38,7 @@ export default class MockOperationStore implements OperationStore {
    * Inserts an operation into the in-memory store.
    */
   private async insert (operation: Operation): Promise<void> {
-    const didUniqueSuffix = operation.didUniqueSuffix!;
+    const didUniqueSuffix = operation.didUniqueSuffix;
 
     this.ensureDidEntriesExist(didUniqueSuffix);
     // Append the operation to the operation array for the did ...


### PR DESCRIPTION
1. Made API for fetching blockchain time async (`approximateTime`).
1. Added caching of blockchain time to improve perf.
1. Improved request response to return error codes if any.
1. Added bad request handling to disallow multiple operations for the same DID.
1. Enforced `Operation` instances to always have a DID unique suffix.
