### PR TITLE
Issue #173 & #211 - Implemented rule of 1 operation per DID per batch.

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -106,9 +106,9 @@ The _batch file_ is a ZIP compressed JSON document of the following schema:
 The _anchor file_ is a JSON document of the following schema:
 ```json
 {
-  "batchFileHash": "Encoded hash of the batch file.",
+  "batchFileHash": "Encoded multihash of the batch file.",
   "didUniqueSuffixes": ["Unique suffix of DID of 1st operation", "Unique suffix of DID of 2nd operation", "..."],
-  "merkleRoot": "Encoded root hash of the Merkle tree constructed from the operations included in the batch file."
+  "merkleRoot": "Encoded multihash of the root of the Merkle tree constructed from the operations included in the batch file."
 }
 ```
 > NOTE: See [Sidetree Operation Receipts](#Sidetree-Operation-Receipts) section on purpose and construction of the `merkleRoot`.
@@ -145,11 +145,19 @@ Sidetree protocol defines the following two mechanisms to enable scaling, while 
 ## Sidetree Transaction Processing
 A Sidetree transaction represents a batch of operations to be processed by Sidetree nodes. Each transaction is assigned a monotonically increasing number (but need not be increasing by one), the _transaction number_ deterministically defines the order of transactions, and thus the order of operations. A _transaction number_ is assigned to all Sidetree transactions irrespective of their validity, however a transaction __must__ be  __valid__ before individual operations within it can be processed. An invalid transaction is simply discarded by Sidetree nodes. The following rules must be followed for determining the validity of a transaction:
 
-1. The corresponding _anchor file_ must strictly follow the schema defined by the protocol. An anchor file with missing or additional properties is invalid.
-1. The corresponding _batch file_ must strictly follow the schema defined by the protocol. A batch file with missing or additional properties is invalid.
-1. The operation batch size must not exceed the maximum size specified by the protocol.
+1. _Anchor file_ validation rules:
+   1. The anchor file must strictly follow the schema defined by the protocol. An anchor file with missing or additional properties is invalid.
+   1. The anchor file fetched from CAS must not exceed the maximum allowed anchor file size.
+   1. Must use the hashing algorithm specified by the protocol.
+   1. All DID unique suffixes specified in the anchor file must be unique.
+1. _Batch file_ validation rules:
+   1. The batch file must strictly follow the schema defined by the protocol. A batch file with missing or additional properties is invalid.
+   1. The batch file fetched from CAS must not exceed the maximum allowed batch file size.
+   1. Must use the hashing algorithm specified by the protocol.
+   1. DID unique suffixes found in the batch file must match DID unique suffixes found in anchor file exactly and in same order.
+   1. The operation batch size must not exceed the maximum size specified by the protocol.
 1. The transaction must meet the proof-of-fee requirements defined by the protocol.
-1. Every operation batched in the same transaction must adhere to the following requirements to be considered a _well-formed operation_, one _not-well-formed_ operation in the batch file renders the entire transaction invalid:
+1. Every operation in the batch file must adhere to the following requirements to be considered a _well-formed operation_, one _not-well-formed_ operation in the batch file renders the entire transaction invalid:
 
    1. Follow the operation schema defined by the protocol, it must not have missing or additional properties.
 
@@ -157,7 +165,7 @@ A Sidetree transaction represents a batch of operations to be processed by Sidet
 
    1. Must use the hashing algorithm specified by the protocol.
 
-> NOTE: A transaction is __not__ considered to be _invalid_ if the corresponding _anchor file_ or _batch file_ cannot be found. Such transactions are _unresolvable transactions_, and must be reprocessed when the its _anchor file_ and _batch file_ become available.
+> NOTE: A transaction is __not__ considered to be _invalid_ if the corresponding _anchor file_ or _batch file_ cannot be found. Such transactions are _unresolvable transactions_, and must be reprocessed when the _anchor file_ or _batch file_ becomes available.
 
 ## DID Deletion and Recovery
 Sidetree protocol requires the specification by the DID owner of dedicated cryptographic keys, called _recovery keys_, for deleting or recovering a DID. At least one recovery key is required to be specified in every _Create_ and _Recover_ operation. Recovery keys can only be changed by another recovery operation. Once a DID is deleted, it cannot be recovered.

--- a/lib/common/ErrorCode.ts
+++ b/lib/common/ErrorCode.ts
@@ -16,6 +16,7 @@ enum ErrorCode {
   AnchorFileMerkleRootNotString = 'anchor_file_merkle_root_not_string',
   AnchorFileMerkleRootUnsupported = 'anchor_file_merkle_root_unsupported',
   AnchorFileNotJson = 'anchor_file_not_json',
+  BatchWriterAlreadyHasOperationForDid = 'batch_writer_already_has_operation_for_did',
   InvalidTransactionNumberOrTimeHash = 'invalid_transaction_number_or_time_hash',
   OperationExceedsMaximumSize = 'operation_exceeds_maximum_size',
   QueueingMultipleOperationsPerDidNotAllowed = 'queueing_multiple_operations_per_did_not_allowed'

--- a/lib/core/MongoDbOperationQueue.ts
+++ b/lib/core/MongoDbOperationQueue.ts
@@ -1,0 +1,128 @@
+import ErrorCode from '../common/ErrorCode';
+import OperationQueue from './OperationQueue';
+import { Binary, Collection, MongoClient, Db } from 'mongodb';
+import { SidetreeError } from './Error';
+
+/**
+ * Sidetree operation stored in MongoDb.
+ * Note: we use the shorter property name "opIndex" instead of "operationIndex" due to a constraint imposed by CosmosDB/MongoDB:
+ * the sum of property names of a unique index keys need to be less than 40 characters.
+ * Note: We represent opIndex, transactionNumber, and transactionTime as long instead of number (double) to avoid some floating
+ * point comparison quirks.
+ */
+interface IMongoQueuedOperation {
+  didUniqueSuffix: string;
+  operationBufferBsonBinary: Binary;
+}
+
+/**
+ * Operation queue used by the Batch Writer implemented using MongoDB.
+ */
+export default class MongoDbOperationQueue implements OperationQueue {
+  /** Collection name for queued operations. */
+  public static readonly collectionName: string = 'queued-operations';
+
+  private collection: Collection<any> | undefined;
+
+  /**
+   * MongoDb database name where the operations are stored
+   */
+  private databaseName: string = 'sidetree';
+
+  private db: Db | undefined;
+
+  constructor (private serverUrl: string, databaseName?: string) {
+    if (databaseName) {
+      this.databaseName = databaseName;
+    }
+  }
+
+  /**
+   * Initialize the MongoDB operation store.
+   */
+  public async initialize () {
+    const client = await MongoClient.connect(this.serverUrl);
+    this.db = client.db(this.databaseName);
+    this.collection = await MongoDbOperationQueue.createCollectionIfNotExist(this.db);
+  }
+
+  async enqueue (didUniqueSuffix: string, operationBuffer: Buffer) {
+    try {
+      const queuedOperation: IMongoQueuedOperation = {
+        didUniqueSuffix,
+        operationBufferBsonBinary: new Binary(operationBuffer)
+      };
+
+      await this.collection!.insertOne(queuedOperation);
+    } catch (error) {
+      // Duplicate insert errors (error code 11000).
+      if (error.code === 11000) {
+        throw new SidetreeError(ErrorCode.BatchWriterAlreadyHasOperationForDid);
+      }
+
+      throw error;
+    }
+  }
+
+  async dequeue (count: number): Promise<Buffer[]> {
+    if (count <= 0) {
+      return [];
+    }
+
+    const queuedOperations = await this.collection!.find().sort({ _id : 1 }).limit(count).toArray();
+    const lastOperation = queuedOperations[queuedOperations.length - 1];
+    await this.collection!.deleteMany({ _id: { $lte: lastOperation._id } });
+
+    return queuedOperations.map((queuedOperation: IMongoQueuedOperation) => queuedOperation.operationBufferBsonBinary.buffer);
+  }
+
+  async peek (count: number): Promise<Buffer[]> {
+    if (count <= 0) {
+      return [];
+    }
+
+    // NOTE: `_id` is the default index that is sorted based by create time.
+    const queuedOperations = await this.collection!.find().sort({ _id : 1 }).limit(count).toArray();
+
+    return queuedOperations.map((queuedOperation: IMongoQueuedOperation) => queuedOperation.operationBufferBsonBinary.buffer);
+  }
+
+  /**
+   * Checks to see if the queue already contains an operation for the given DID unique suffix.
+   */
+  async contains (didUniqueSuffix: string): Promise<boolean> {
+    const operations = await this.collection!.find({ didUniqueSuffix }).limit(1).toArray();
+    return operations.length > 0;
+  }
+
+  /**
+   * * Clears the unresolvable transaction store. Mainly used in tests.
+   */
+  public async clearCollection () {
+    await this.collection!.drop();
+    this.collection = await MongoDbOperationQueue.createCollectionIfNotExist(this.db!);
+  }
+
+  /**
+   * Creates the queued operation collection with indexes if it does not exists.
+   * @returns The existing collection if exists, else the newly created collection.
+   */
+  private static async createCollectionIfNotExist (db: Db): Promise<Collection<IMongoQueuedOperation>> {
+    // Get the names of existing collections.
+    const collections = await db.collections();
+    const collectionNames = collections.map(collection => collection.collectionName);
+
+    // If the queued operation collection exists, use it; else create it then use it.
+    let collection;
+    if (collectionNames.includes(this.collectionName)) {
+      collection = db.collection(this.collectionName);
+    } else {
+      collection = await db.createCollection(this.collectionName);
+      // Create an index on didUniqueSuffix make `contains()` operations more efficient.
+      // This is an unique index, so duplicate inserts are rejected.
+      await collection.createIndex({ didUniqueSuffix: 1 }, { unique: true });
+    }
+
+    return collection;
+  }
+}

--- a/lib/core/OperationQueue.ts
+++ b/lib/core/OperationQueue.ts
@@ -1,0 +1,26 @@
+/**
+ * An abstraction of a queue of operations used by the Batch Writer.
+ */
+export default interface OperationQueue {
+
+  /**
+   * Places an operation at the tail of the queue.
+   * If there is already an operation for the same DID, Sidetree Error is thrown with 'code': 'batch_writer_already_has_operation_for_did'.
+   */
+  enqueue (didUniqueSuffix: string, operationBuffer: Buffer): Promise<void>;
+
+  /**
+   * Removes the given count of operation buffers from the beginning of the queue.
+   */
+  dequeue (count: number): Promise<Buffer[]>;
+
+  /**
+   * Fetches the given count of operation buffers from the beginning of the queue without removing them.
+   */
+  peek (count: number): Promise<Buffer[]>;
+
+  /**
+   * Checks to see if the queue already contains an operation for the given DID unique suffix.
+   */
+  contains (didUniqueSuffix: string): Promise<boolean>;
+}

--- a/lib/core/RequestHandler.ts
+++ b/lib/core/RequestHandler.ts
@@ -26,7 +26,7 @@ export default class RequestHandler {
   /**
    * Handles an operation request.
    */
-  public handleOperationRequest (request: Buffer): IResponse {
+  public async handleOperationRequest (request: Buffer): Promise<IResponse> {
     console.info(`Handling operation request of size ${request.length} bytes...`);
     // Get the protocol version according to current blockchain time to validate the operation request.
     const currentTime = this.blockchain.approximateTime;
@@ -46,7 +46,7 @@ export default class RequestHandler {
       operation = Operation.createUnanchoredOperation(request, currentTime.time);
 
       // Reject operation if there is already an operation for the same DID waiting to be batched and anchored.
-      if (this.batchWriter.hasOperationQueuedFor(operation.didUniqueSuffix)) {
+      if (await this.batchWriter.hasOperationQueuedFor(operation.didUniqueSuffix)) {
         throw new SidetreeError(ErrorCode.QueueingMultipleOperationsPerDidNotAllowed);
       }
     } catch (error) {
@@ -94,7 +94,7 @@ export default class RequestHandler {
 
       // if the operation was processed successfully, queue the original request buffer for batching.
       if (response.status === ResponseStatus.Succeeded) {
-        this.batchWriter.add(operation);
+        await this.batchWriter.add(operation);
       }
 
       return response;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@decentralized-identity/did-common-typescript": "0.1.2",
     "base64url": "3.0.1",
     "bitcore-lib": "8.3.0",
-    "double-ended-queue": "2.1.0-0",
     "fast-json-patch": "2.1.0",
     "http-status": "1.3.2",
     "ipfs": "0.35.0",

--- a/src/core.ts
+++ b/src/core.ts
@@ -29,7 +29,7 @@ app.use(async (ctx, next) => {
 
 const router = new Router();
 router.post('/', async (ctx, _next) => {
-  const response = sidetreeCore.requestHandler.handleOperationRequest(ctx.body);
+  const response = await sidetreeCore.requestHandler.handleOperationRequest(ctx.body);
   setKoaResponse(response, ctx.response);
 });
 

--- a/tests/core/MongoDbOperationQueue.spec.ts
+++ b/tests/core/MongoDbOperationQueue.spec.ts
@@ -1,0 +1,160 @@
+import ErrorCode from '../../lib/common/ErrorCode';
+import IConfig from '../../lib/core/IConfig';
+import MongoDbOperationQueue from '../../lib/core/MongoDbOperationQueue';
+import OperationQueue from '../../lib/core/OperationQueue';
+import { MongoClient } from 'mongodb';
+import { SidetreeError } from '../../lib/core/Error';
+
+/**
+ * Test if a MongoDB service is running at the specified url.
+ */
+async function isMongoServiceAvailable (serverUrl: string): Promise<boolean> {
+  try {
+    const client = await MongoClient.connect(serverUrl);
+    await client.close();
+  } catch (error) {
+    console.log('Mongoclient connect error: ' + error);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Creates a MongoDbOperationQueue and initializes it.
+ */
+async function createOperationQueue (transactionStoreUri: string, databaseName: string): Promise<MongoDbOperationQueue> {
+  const operationQueue = new MongoDbOperationQueue(transactionStoreUri, databaseName);
+  await operationQueue.initialize();
+  return operationQueue;
+}
+
+/**
+ * Generates the given count of operations and queues them in the given operation queue.
+ * e.g. The DID unique suffix will start from '1', '2', '3'... and buffer will be generated from the DID unique suffix.
+ */
+async function generateAndQueueOperations (operationQueue: OperationQueue, count: number): Promise<{ didUniqueSuffix: string, operationBuffer: Buffer }[]> {
+  const operations: { didUniqueSuffix: string, operationBuffer: Buffer }[] = [];
+  for (let i = 1; i <= count; i++) {
+    const didUniqueSuffix = i.toString();
+    const operationBuffer = Buffer.from(didUniqueSuffix);
+
+    operations.push({ didUniqueSuffix, operationBuffer });
+    await operationQueue.enqueue(didUniqueSuffix, operationBuffer);
+  }
+
+  return operations;
+}
+
+describe('MongoDbOperationQueue', async () => {
+  const config: IConfig = require('../json/config-test.json');
+  const databaseName = 'sidetree-test';
+
+  let mongoServiceAvailable = false;
+  let operationQueue: MongoDbOperationQueue;
+  beforeAll(async () => {
+    mongoServiceAvailable = await isMongoServiceAvailable(config.mongoDbConnectionString);
+    operationQueue = await createOperationQueue(config.mongoDbConnectionString, databaseName);
+  });
+
+  beforeEach(async () => {
+    if (!mongoServiceAvailable) {
+      pending('MongoDB service not available');
+    }
+
+    await operationQueue.clearCollection();
+  });
+
+  it('should peek with correct count.', async () => {
+    const operationCount = 3;
+    const queuedOperations = await generateAndQueueOperations(operationQueue, operationCount);
+
+    // Expect empty array if peeked with count 0.
+    let peekedOperations = await operationQueue.peek(0);
+    expect(peekedOperations).not.toBeNull();
+    expect(peekedOperations.length).toBe(0);
+
+    // Expected same result no matter how many times the queue is peeked.
+    for (let i = 0; i < 5; i++) {
+      peekedOperations = await operationQueue.peek(2);
+      expect(peekedOperations.length).toEqual(2);
+      expect(peekedOperations[0].toString()).toEqual(queuedOperations[0].operationBuffer.toString());
+      expect(peekedOperations[1].toString()).toEqual(queuedOperations[1].operationBuffer.toString());
+    }
+  });
+
+  it('should deqeueue with correct count.', async () => {
+    const operationCount = 3;
+    const queuedOperations = await generateAndQueueOperations(operationQueue, operationCount);
+
+    // Expect empty array if peeked with count 0.
+    let dequeuedOperations = await operationQueue.dequeue(0);
+    expect(dequeuedOperations).not.toBeNull();
+    expect(dequeuedOperations.length).toBe(0);
+
+    dequeuedOperations = await operationQueue.dequeue(2);
+    let remainingOperations = await operationQueue.peek(operationCount);
+    expect(dequeuedOperations.length).toEqual(2);
+    expect(dequeuedOperations[0].toString()).toEqual(queuedOperations[0].operationBuffer.toString());
+    expect(dequeuedOperations[1].toString()).toEqual(queuedOperations[1].operationBuffer.toString());
+
+    expect(remainingOperations.length).toEqual(1);
+    expect(remainingOperations[0].toString()).toEqual(queuedOperations[2].operationBuffer.toString());
+  });
+
+  it('should check if an operation of the given DID unique suffix exists correctly.', async () => {
+    const operationCount = 3;
+    await generateAndQueueOperations(operationQueue, operationCount);
+
+    for (let i = 1; i <= operationCount; i++) {
+      const operationExists = await operationQueue.contains(i.toString());
+      expect(operationExists).toBeTruthy();
+    }
+
+    const operationExists = await operationQueue.contains('non-existent-did-unique-suffix');
+    expect(operationExists).toBeFalsy();
+  });
+
+  it('should throw SidetreeError with code when enqueueing more than 1 operation for DID.', async () => {
+    const operationCount = 3;
+    await generateAndQueueOperations(operationQueue, operationCount);
+
+    spyOn((operationQueue as any).collection, 'insertOne').and.callFake(
+      () => {
+        const error = new Error(ErrorCode.BatchWriterAlreadyHasOperationForDid);
+        (error as any)['code'] = 11000;
+        throw error;
+      }
+    );
+
+    try {
+      await generateAndQueueOperations(operationQueue, operationCount);
+    } catch (error) {
+      if (error instanceof SidetreeError &&
+          error.code === ErrorCode.BatchWriterAlreadyHasOperationForDid) {
+        return; // Expected Sidetree error.
+      } else {
+        throw error; // Unexpected error, throw to fail the test.
+      }
+    }
+  });
+
+  it('should throw original error if unexpected error is thrown when enqueuing.', async () => {
+    spyOn((operationQueue as any).collection, 'insertOne').and.callFake(
+      () => {
+        const error = new Error(ErrorCode.BatchWriterAlreadyHasOperationForDid);
+        (error as any)['code'] = 'unexpected-error';
+        throw error;
+      }
+    );
+
+    try {
+      await generateAndQueueOperations(operationQueue, 1);
+    } catch (error) {
+      if (error.code === 'unexpected-error') {
+        return; // Expected behavior.
+      } else {
+        throw error; // Unexpected behavior, throw to fail the test.
+      }
+    }
+  });
+});

--- a/tests/mocks/MockOperationQueue.ts
+++ b/tests/mocks/MockOperationQueue.ts
@@ -1,0 +1,40 @@
+import OperationQueue from '../../lib/core/OperationQueue';
+
+/**
+ * A mock in-memory operation queue used by the Batch Writer.
+ */
+export default class MockOperationQueue implements OperationQueue {
+  private latestTimestamp = 0;
+  private operations: Map<string, [number, Buffer]> = new Map();
+
+  async enqueue (didUniqueSuffix: string, operationBuffer: Buffer) {
+    this.latestTimestamp++;
+    this.operations.set(didUniqueSuffix, [this.latestTimestamp, operationBuffer]);
+  }
+
+  async dequeue (count: number): Promise<Buffer[]> {
+    // Sort the entries by their timestamp.
+    const sortedEntries = Array.from(this.operations.entries()).sort((a, b) => b[1][0] - a[1][0]);
+    const sortedKeys = sortedEntries.map(entry => entry[0]);
+    const sortedBuffers = sortedEntries.map(entry => entry[1][1]);
+
+    const bufferBatch = sortedBuffers.slice(0, count);
+    const keyBatch = sortedKeys.slice(0, count);
+    keyBatch.forEach((key) => this.operations.delete(key));
+
+    return bufferBatch;
+  }
+
+  async peek (count: number): Promise<Buffer[]> {
+    // Sort the entries by their timestamp.
+    const sortedValues = Array.from(this.operations.values()).sort((a, b) => b[0] - a[0]);
+    const sortedBuffers = sortedValues.map(entry => entry[1]);
+
+    const bufferBatch = sortedBuffers.slice(0, count);
+    return bufferBatch;
+  }
+
+  async contains (didUniqueSuffix: string): Promise<boolean> {
+    return this.operations.has(didUniqueSuffix);
+  }
+}


### PR DESCRIPTION
* Issue #173 - Implemented rule of 1 operation per DID per batch.
* Updated protocol documentation to include 1 operation per DID per batch rule.
* Issue #211 - Persisted operations queued to be anchored in case of a node crash.
* Added tests with 100% code coverage on MongoDB operation queue implementation.