### PR TITLE
#216 Updating the proof of fee changes to address leftover issues

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -419,7 +419,7 @@ Fetches the normalized transaction fee used for proof-of-fee calculation, given 
 
 Returns `HTTP 400 Bad Request` with `blockchain_time_out_of_range` as the `code` parameter value in the JSON body if the given blockchain time is:
 1. earlier than the genesis Sidetree blockchain time; or
-1. later than the current blockchain time.
+1. later than the blockchain time of the block that the service has processed.
 
 Returns `HTTP 500 Internal Server Error` with `normalized_fee_cannot_be_computed` as the `code` parameter value in the JSON body if the server is unable to compute the normalized fee.
 #### Request path

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -456,6 +456,14 @@ HTTP/1.1 200 OK
 }
 ```
 
+#### Response example - Blockchain time given is out of computable range.	
+```http
+HTTP/1.1 500 Internal Server Error
+{
+  "code": "blockchain_time_out_of_range"
+}
+```
+
 #### Response example - Error while computing the normalized fee.
 
 ```http

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -458,7 +458,7 @@ HTTP/1.1 200 OK
 
 #### Response example - Blockchain time given is out of computable range.	
 ```http
-HTTP/1.1 500 Internal Server Error
+HTTP/1.1 400 Bad Request
 {
   "code": "blockchain_time_out_of_range"
 }

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -419,7 +419,7 @@ Fetches the normalized transaction fee used for proof-of-fee calculation, given 
 
 Returns `HTTP 400 Bad Request` with `blockchain_time_out_of_range` as the `code` parameter value in the JSON body if the given blockchain time is:
 1. earlier than the genesis Sidetree blockchain time; or
-1. later than the blockchain time of the block that the service has processed.
+1. later than the blockchain time of the latest block that the service has processed.
 
 Returns `HTTP 500 Internal Server Error` with `normalized_fee_cannot_be_computed` as the `code` parameter value in the JSON body if the server is unable to compute the normalized fee.
 #### Request path

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -421,6 +421,7 @@ Returns `HTTP 400 Bad Request` with `blockchain_time_out_of_range` as the `code`
 1. earlier than the genesis Sidetree blockchain time; or
 1. later than the current blockchain time.
 
+Returns `HTTP 500 Internal Server Error` with `normalized_fee_cannot_be_computed` as the `code` parameter value in the JSON body if the server is unable to compute the normalized fee.
 #### Request path
 ```
 GET /fee
@@ -455,13 +456,13 @@ HTTP/1.1 200 OK
 }
 ```
 
-#### Response example - Blockchain time given is out of computable range.
+#### Response example - Error while computing the normalized fee.
 
 ```http
-HTTP/1.1 400 Bad Request
+HTTP/1.1 500 Internal Server Error
 
 {
-  "code": "blockchain_time_out_of_range"
+  "code": "normalized_fee_cannot_be_computed"
 }
 ```
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -465,7 +465,6 @@ HTTP/1.1 400 Bad Request
 ```
 
 #### Response example - Error while computing the normalized fee.
-
 ```http
 HTTP/1.1 500 Internal Server Error
 

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -77,7 +77,7 @@ export default class BitcoinProcessor {
   public lowBalanceNoticeDays: number;
 
   /** Last seen block */
-  private lastSeenBlock: IBlockInfo | undefined;
+  private lastProcessedBlock: IBlockInfo | undefined;
 
   /** Poll timeout identifier */
   private pollTimeoutId: number | undefined;
@@ -102,8 +102,7 @@ export default class BitcoinProcessor {
     this.transactionStore = new MongoDbTransactionStore(config.mongoDbConnectionString, config.databaseName);
 
     const mongoQuantileStore = new MongoDbSlidingWindowQuantileStore(config.mongoDbConnectionString, config.databaseName);
-    this.quantileCalculator = new SlidingWindowQuantileCalculator(ProtocolParameters.feeApproximation,
-      BitcoinProcessor.satoshiPerBitcoin,
+    this.quantileCalculator = new SlidingWindowQuantileCalculator(BitcoinProcessor.satoshiPerBitcoin,
       ProtocolParameters.windowSizeInGroups,
       ProtocolParameters.quantileMeasure,
       mongoQuantileStore);
@@ -169,10 +168,10 @@ export default class BitcoinProcessor {
     const lastKnownTransaction = await this.transactionStore.getLastTransaction();
     if (lastKnownTransaction) {
       console.info(`Last known block ${lastKnownTransaction.transactionTime} (${lastKnownTransaction.transactionTimeHash})`);
-      this.lastSeenBlock = { height: lastKnownTransaction.transactionTime, hash: lastKnownTransaction.transactionTimeHash };
-      this.lastSeenBlock = await this.processTransactions(this.lastSeenBlock);
+      const startingBlock: IBlockInfo = { height: lastKnownTransaction.transactionTime, hash: lastKnownTransaction.transactionTimeHash };
+      await this.processTransactions(startingBlock);
     } else {
-      this.lastSeenBlock = await this.processTransactions();
+      await this.processTransactions();
     }
     // disabling floating promise lint since periodicPoll should just float in the background event loop
     /* tslint:disable-next-line:no-floating-promises */
@@ -325,7 +324,7 @@ export default class BitcoinProcessor {
       throw new RequestError(ResponseStatus.BadRequest, ErrorCode.BlockchainTimeOutOfRange);
     }
 
-    const currentBlockNumber = await this.getCurrentBlockHeight();
+    const currentBlockNumber = this.lastProcessedBlock ? this.lastProcessedBlock.height : await this.getCurrentBlockHeight();
     if (block > currentBlockNumber) {
       const error = `The input block number must be less than or equal to: ${currentBlockNumber}`;
       console.error(error);
@@ -340,7 +339,8 @@ export default class BitcoinProcessor {
       return { normalizedTransactionFee: quantileValue };
     }
 
-    throw new RequestError(ResponseStatus.ServerError, ErrorCode.NormalizedFeeCouldNotBeCaclculated);
+    console.error(`Unable to get the normalized fee from the quantile calculator for block: ${block}. Seems like that the service isn't ready yet.`);
+    throw new RequestError(ResponseStatus.ServerError, ErrorCode.NormalizedFeeCannotBeComputed);
   }
 
   /**
@@ -423,8 +423,7 @@ export default class BitcoinProcessor {
     }
 
     try {
-      const syncedTo = await this.processTransactions(this.lastSeenBlock);
-      this.lastSeenBlock = syncedTo;
+      await this.processTransactions(this.lastProcessedBlock);
     } catch (error) {
       console.error(error);
     } finally {
@@ -439,12 +438,15 @@ export default class BitcoinProcessor {
    * @returns The block height and hash it processed to
    */
   private async processTransactions (startBlock?: IBlockInfo, endBlockHeight?: number): Promise<IBlockInfo> {
+    console.info(`Starting processTransaction at: ${Date.now()}`);
+
     let startBlockHeight: number;
     if (startBlock) {
       const startValid = await this.verifyBlock(startBlock.height, startBlock.hash);
       startBlockHeight = startBlock.height;
       if (!startValid) {
-        startBlockHeight = await this.revertBlockchainCache();
+        this.lastProcessedBlock = await this.revertBlockchainCache();
+        startBlockHeight = this.lastProcessedBlock.height;
       }
     } else {
       startBlockHeight = this.genesisBlockNumber;
@@ -459,15 +461,17 @@ export default class BitcoinProcessor {
 
     console.info(`Processing transactions from ${startBlockHeight} to ${endBlockHeight}`);
 
-    for (let blockHeight = startBlockHeight; blockHeight < endBlockHeight; blockHeight++) {
-      await this.processBlock(blockHeight);
+    for (let blockHeight = startBlockHeight; blockHeight <= endBlockHeight; blockHeight++) {
+      const processedBlockHash = await this.processBlock(blockHeight);
+
+      this.lastProcessedBlock = {
+        height: blockHeight,
+        hash: processedBlockHash
+      };
     }
-    const hash = await this.processBlock(endBlockHeight);
+
     console.info(`Finished processing blocks ${startBlockHeight} to ${endBlockHeight}`);
-    return {
-      hash,
-      height: endBlockHeight
-    };
+    return this.lastProcessedBlock!;
   }
 
   /**
@@ -484,7 +488,7 @@ export default class BitcoinProcessor {
    * Begins to revert the blockchain cache until consistent, returns last good height
    * @returns last valid block height before the fork
    */
-  private async revertBlockchainCache (): Promise<number> {
+  private async revertBlockchainCache (): Promise<IBlockInfo> {
     console.info('Reverting transactions');
 
     // Keep reverting transactions until a valid transaction is found.
@@ -512,7 +516,10 @@ export default class BitcoinProcessor {
         await this.quantileCalculator.removeGroupsGreaterThanOrEqual(revertToBlockNumber + 1);
 
         console.info(`reverted Transactions to block ${revertToBlockNumber}`);
-        return revertToBlockNumber;
+        return {
+          height: revertToBlockNumber,
+          hash: await this.getBlockHash(revertToBlockNumber)
+        };
       }
 
       // We did not find a valid transaction - revert as much as the lowest height in the exponentially spaced
@@ -526,7 +533,10 @@ export default class BitcoinProcessor {
 
     // there are no transactions stored.
     console.info('Reverted all known transactions.');
-    return this.genesisBlockNumber;
+    return {
+      height: this.genesisBlockNumber,
+      hash: await this.getBlockHash(this.genesisBlockNumber)
+    };
   }
 
   /**

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -324,7 +324,10 @@ export default class BitcoinProcessor {
       throw new RequestError(ResponseStatus.BadRequest, ErrorCode.BlockchainTimeOutOfRange);
     }
 
-    const currentBlockNumber = this.lastProcessedBlock ? this.lastProcessedBlock.height : await this.getCurrentBlockHeight();
+    // Our code pattern dictates that the initialize() call must be finished before the service is ready to
+    // process any client requests so we can assume that hte lastProcessedBlock variable is actually set
+    // and not undefined at this point.
+    const currentBlockNumber = this.lastProcessedBlock!.height;
     if (block > currentBlockNumber) {
       const error = `The input block number must be less than or equal to: ${currentBlockNumber}`;
       console.error(error);

--- a/lib/bitcoin/fee/SlidingWindowQuantileCalculator.ts
+++ b/lib/bitcoin/fee/SlidingWindowQuantileCalculator.ts
@@ -28,6 +28,10 @@ export default class SlidingWindowQuantileCalculator {
   private valueApproximator: ValueApproximator;
 
   /**
+   * The value to use as an input to the ValueApproximator.
+   */
+  private readonly feeApproximate: number = 2;
+  /**
    * Size of a frequency vector; 1 + max normalized value
    */
   private frequencyVectorSize: number;
@@ -59,13 +63,12 @@ export default class SlidingWindowQuantileCalculator {
    * approximation paramenters.
    */
   public constructor (
-    approximation: number,  // approximation used to round up values (to reduce storage)
     maxValue: number,  // all values above maxValue are rounded down by maxValue
     private readonly slidingWindowSize: number, // size of the sliding window used to compute quantiles
     private readonly quantileMeasure: number, // quantile measure (e.g., 0.5) that is tracked by the calculator
     private readonly mongoStore: ISlidingWindowQuantileStore
     ) {
-    this.valueApproximator = new ValueApproximator(approximation, maxValue);
+    this.valueApproximator = new ValueApproximator(this.feeApproximate, maxValue);
     this.frequencyVectorSize = 1 + this.valueApproximator.getMaximumNormalizedValue();
     this.slidingWindow = new Array<FrequencyVector>();
     this.frequencyVectorAggregated = new Array(this.frequencyVectorSize).fill(0);

--- a/lib/bitcoin/models/ProtocolParameters.ts
+++ b/lib/bitcoin/models/ProtocolParameters.ts
@@ -9,14 +9,6 @@ export default interface ProtocolParameters {
   /** Size of the window in number of groups */
   windowSizeInGroups: number;
 
-  /**
-   * Transaction fees of bitcoin transactions are rounded so that we need to store
-   * a smaller number of distinct values for computing quantiles. This parameter controls
-   * the rounding - higher the value, poorer the rounded value approximates the original fee,
-   * but lesser the space.
-   */
-  feeApproximation: number;
-
   /** Number of samples we store per-group */
   sampleSizePerGroup: number;
 

--- a/lib/bitcoin/protocol-parameters.json
+++ b/lib/bitcoin/protocol-parameters.json
@@ -1,7 +1,6 @@
 {
   "groupSizeInBlocks": 100,
   "windowSizeInGroups": 10,
-  "feeApproximation": 1.5,
   "sampleSizePerGroup": 25,
   "quantileMeasure": 0.5,
 

--- a/lib/common/SharedErrorCode.ts
+++ b/lib/common/SharedErrorCode.ts
@@ -4,5 +4,5 @@
 export default {
   BlockchainTimeOutOfRange: 'blockchain_time_out_of_range',
   InvalidTransactionNumberOrTimeHash: 'invalid_transaction_number_or_time_hash',
-  NormalizedFeeCouldNotBeCaclculated: 'normalized_fee_could_not_be_calculated'
+  NormalizedFeeCannotBeComputed: 'normalized_fee_cannot_be_computed'
 };

--- a/tests/bitcoin/BitcoinProcessor.spec.ts
+++ b/tests/bitcoin/BitcoinProcessor.spec.ts
@@ -520,7 +520,7 @@ describe('BitcoinProcessor', () => {
       }
     });
 
-    it('should throw if the input is greter than the current block height.', async () => {
+    it('should throw if the input is greater than the current block height.', async () => {
 
       try {
         await bitcoinProcessor.getNormalizedFee(mockedCurrentHeight + 1);
@@ -539,7 +539,7 @@ describe('BitcoinProcessor', () => {
         fail('should have failed');
       } catch (error) {
         expect(error.status).toEqual(httpStatus.INTERNAL_SERVER_ERROR);
-        expect(error.code).toEqual(ErrorCode.NormalizedFeeCouldNotBeCaclculated);
+        expect(error.code).toEqual(ErrorCode.NormalizedFeeCannotBeComputed);
       }
     });
 
@@ -643,7 +643,7 @@ describe('BitcoinProcessor', () => {
       const lastBlock = randomBlock();
       const nextBlock = randomNumber();
       const nextHash = randomString();
-      bitcoinProcessor['lastSeenBlock'] = lastBlock;
+      bitcoinProcessor['lastProcessedBlock'] = lastBlock;
       processTransactionsSpy.and.callFake((block: IBlockInfo) => {
         expect(block.height).toEqual(lastBlock.height);
         expect(block.hash).toEqual(lastBlock.hash);
@@ -656,13 +656,13 @@ describe('BitcoinProcessor', () => {
       bitcoinProcessor['periodicPoll']();
       // need to wait for the process call
       setTimeout(() => {
-        expect(bitcoinProcessor['lastSeenBlock']!.hash).toEqual(nextHash);
-        expect(bitcoinProcessor['lastSeenBlock']!.height).toEqual(nextBlock);
         expect(bitcoinProcessor['pollTimeoutId']).toBeDefined();
         // clean up
         clearTimeout(bitcoinProcessor['pollTimeoutId']);
         done();
       }, 300);
+
+      expect(processTransactionsSpy).toHaveBeenCalled();
     });
 
     it('should set a timeout to call itself', async (done) => {
@@ -696,21 +696,27 @@ describe('BitcoinProcessor', () => {
       const actual = await bitcoinProcessor['processTransactions'](startBlock, startBlock.height + 1);
       expect(actual.hash).toEqual(hash);
       expect(actual.height).toEqual(startBlock.height + 1);
+      expect(bitcoinProcessor['lastProcessedBlock']).toBeDefined();
+      expect(actual).toEqual(bitcoinProcessor['lastProcessedBlock']!);
       expect(verifySpy).toHaveBeenCalled();
       expect(processMock).toHaveBeenCalled();
       done();
     });
 
     it('should begin a rollback if the start block failed to validate', async (done) => {
-      const hash = randomString();
       const startBlock = randomBlock(testConfig.genesisBlockNumber + 100);
+      const hash = randomString();
       const revertNumber = startBlock.height - 100;
       const verifySpy = spyOn(bitcoinProcessor, 'verifyBlock' as any).and.returnValue(Promise.resolve(false));
-      const revertSpy = spyOn(bitcoinProcessor, 'revertBlockchainCache' as any).and.returnValue(Promise.resolve(revertNumber));
+      const revertSpy = spyOn(bitcoinProcessor, 'revertBlockchainCache' as any);
+      revertSpy.and.returnValue(Promise.resolve({ height: revertNumber, hash: 'some_hash' }));
+
       const processMock = spyOn(bitcoinProcessor, 'processBlock' as any).and.returnValue(Promise.resolve(hash));
       const actual = await bitcoinProcessor['processTransactions'](startBlock, startBlock.height + 1);
       expect(actual.height).toEqual(startBlock.height + 1);
       expect(actual.hash).toEqual(hash);
+      expect(bitcoinProcessor['lastProcessedBlock']).toBeDefined();
+      expect(actual).toEqual(bitcoinProcessor['lastProcessedBlock']!);
       expect(verifySpy).toHaveBeenCalled();
       expect(revertSpy).toHaveBeenCalled();
       expect(processMock).toHaveBeenCalledWith(revertNumber);
@@ -723,7 +729,9 @@ describe('BitcoinProcessor', () => {
       const startBlock = randomBlock(testConfig.genesisBlockNumber);
       const verifySpy = spyOn(bitcoinProcessor, 'verifyBlock' as any).and.returnValue(Promise.resolve(true));
       const processMock = spyOn(bitcoinProcessor, 'processBlock' as any).and.returnValue(Promise.resolve(hash));
-      await bitcoinProcessor['processTransactions'](startBlock, startBlock.height + 9);
+      const actual = await bitcoinProcessor['processTransactions'](startBlock, startBlock.height + 9);
+      expect(bitcoinProcessor['lastProcessedBlock']).toBeDefined();
+      expect(actual).toEqual(bitcoinProcessor['lastProcessedBlock']!);
       expect(verifySpy).toHaveBeenCalled();
       expect(processMock).toHaveBeenCalledTimes(10);
       done();
@@ -735,7 +743,9 @@ describe('BitcoinProcessor', () => {
       const verifySpy = spyOn(bitcoinProcessor, 'verifyBlock' as any).and.returnValue(Promise.resolve(true));
       const tipSpy = spyOn(bitcoinProcessor, 'getCurrentBlockHeight' as any).and.returnValue(Promise.resolve(startBlock.height + 1));
       const processMock = spyOn(bitcoinProcessor, 'processBlock' as any).and.returnValue(Promise.resolve(hash));
-      await bitcoinProcessor['processTransactions'](startBlock);
+      const actual = await bitcoinProcessor['processTransactions'](startBlock);
+      expect(bitcoinProcessor['lastProcessedBlock']).toBeDefined();
+      expect(actual).toEqual(bitcoinProcessor['lastProcessedBlock']!);
       expect(verifySpy).toHaveBeenCalled();
       expect(tipSpy).toHaveBeenCalled();
       expect(processMock).toHaveBeenCalledTimes(2);
@@ -746,7 +756,9 @@ describe('BitcoinProcessor', () => {
       const verifySpy = spyOn(bitcoinProcessor, 'verifyBlock' as any);
       const tipSpy = spyOn(bitcoinProcessor, 'getCurrentBlockHeight' as any).and.returnValue(Promise.resolve(testConfig.genesisBlockNumber + 1));
       const processMock = spyOn(bitcoinProcessor, 'processBlock' as any).and.returnValue(Promise.resolve(randomString()));
-      await bitcoinProcessor['processTransactions']();
+      const actual = await bitcoinProcessor['processTransactions']();
+      expect(bitcoinProcessor['lastProcessedBlock']).toBeDefined();
+      expect(actual).toEqual(bitcoinProcessor['lastProcessedBlock']!);
       expect(verifySpy).not.toHaveBeenCalled();
       expect(tipSpy).toHaveBeenCalled();
       expect(processMock).toHaveBeenCalledTimes(2);
@@ -806,8 +818,12 @@ describe('BitcoinProcessor', () => {
         return block;
       });
 
+      const mockHash = 'mock_hash';
+      spyOn(bitcoinProcessor,'getBlockHash' as any).and.returnValue(Promise.resolve(mockHash));
+
       const actual = await bitcoinProcessor['revertBlockchainCache']();
-      expect(actual).toEqual(transactions[1].transactionTime);
+      expect(actual.height).toEqual(transactions[1].transactionTime);
+      expect(actual.hash).toEqual(mockHash);
       expect(transactionCount).toHaveBeenCalled();
       expect(exponentialTransactions).toHaveBeenCalled();
       expect(firstValid).toHaveBeenCalled();
@@ -840,8 +856,12 @@ describe('BitcoinProcessor', () => {
         return block;
       });
 
+      const mockHash = 'mock_hash';
+      spyOn(bitcoinProcessor,'getBlockHash' as any).and.returnValue(Promise.resolve(mockHash));
+
       const actual = await bitcoinProcessor['revertBlockchainCache']();
-      expect(actual).toEqual(transactions[0].transactionTime);
+      expect(actual.height).toEqual(transactions[0].transactionTime);
+      expect(actual.hash).toEqual(mockHash);
       expect(transactionCount).toHaveBeenCalledTimes(2);
       expect(exponentialTransactions).toHaveBeenCalledTimes(2);
       expect(firstValid).toHaveBeenCalledTimes(2);
@@ -867,8 +887,13 @@ describe('BitcoinProcessor', () => {
           return Promise.resolve();
         });
       spyOn(bitcoinProcessor['quantileCalculator'], 'removeGroupsGreaterThanOrEqual').and.returnValue(Promise.resolve());
+
+      const mockHash = 'mock_hash';
+      spyOn(bitcoinProcessor,'getBlockHash' as any).and.returnValue(Promise.resolve(mockHash));
+
       const actual = await bitcoinProcessor['revertBlockchainCache']();
-      expect(actual).toEqual(testConfig.genesisBlockNumber);
+      expect(actual.height).toEqual(testConfig.genesisBlockNumber);
+      expect(actual.hash).toEqual(mockHash);
       expect(transactionCount).toHaveBeenCalled();
       expect(exponentialTransactions).toHaveBeenCalled();
       expect(firstValid).toHaveBeenCalled();

--- a/tests/bitcoin/BitcoinProcessor.spec.ts
+++ b/tests/bitcoin/BitcoinProcessor.spec.ts
@@ -508,6 +508,7 @@ describe('BitcoinProcessor', () => {
       validBlockHeight = mockedCurrentHeight - 50;
 
       spyOn(bitcoinProcessor, 'getCurrentBlockHeight' as any).and.returnValue(Promise.resolve(mockedCurrentHeight));
+      bitcoinProcessor['lastProcessedBlock'] = { height: mockedCurrentHeight, hash: 'mocked_hash' };
     });
 
     it('should throw if the input is less than the genesis block', async () => {
@@ -520,7 +521,7 @@ describe('BitcoinProcessor', () => {
       }
     });
 
-    it('should throw if the input is greater than the current block height.', async () => {
+    it('should throw if the input is greater than the last processed block height.', async () => {
 
       try {
         await bitcoinProcessor.getNormalizedFee(mockedCurrentHeight + 1);

--- a/tests/bitcoin/pof/SlidingWindowQuantileCalculator.spec.ts
+++ b/tests/bitcoin/pof/SlidingWindowQuantileCalculator.spec.ts
@@ -3,7 +3,6 @@ import MockSlidingWindowQuantileStore from '../../mocks/MockSlidingWindowQuantil
 import SlidingWindowQuantileCalculator from '../../../lib/bitcoin/fee/SlidingWindowQuantileCalculator';
 
 describe('SlidingWindowQuantileCalculator', async () => {
-  const valueApproximation = 2;
   const maxValue = 128;
   const slidingWindowSize = 2;
   const medianQuantile = 0.5;
@@ -13,7 +12,7 @@ describe('SlidingWindowQuantileCalculator', async () => {
   beforeAll(async () => {
     slidingWindowQuantileStore = new MockSlidingWindowQuantileStore();
     slidingWindowQuantileCalculator = new SlidingWindowQuantileCalculator(
-      valueApproximation, maxValue, slidingWindowSize, medianQuantile, slidingWindowQuantileStore);
+      maxValue, slidingWindowSize, medianQuantile, slidingWindowQuantileStore);
     await slidingWindowQuantileCalculator.initialize();
   });
 
@@ -146,7 +145,7 @@ describe('SlidingWindowQuantileCalculator', async () => {
 
     // start a new calculator with the same store
     slidingWindowQuantileCalculator = new SlidingWindowQuantileCalculator(
-      valueApproximation, maxValue, slidingWindowSize, medianQuantile, slidingWindowQuantileStore);
+      maxValue, slidingWindowSize, medianQuantile, slidingWindowQuantileStore);
     await slidingWindowQuantileCalculator.initialize();
 
     // quantile of 0 is over [2x100], so 2


### PR DESCRIPTION
Following changes are in this PR:
1. The ```feeApproximation``` protocol parameter has been removed. Instead the code now uses the hardcoded value.
1. Renamed the ```lastSeenBlock``` to ```lastProcessedBlock``` in ```BitcoinProcessor.ts```.
1. The ```lastProcessedBlock``` is now only being updated in the ```processTransactions``` function. This ensures that the status of this variable is up to date even during the revert process.
1. The ```getNormalizedFee``` function now checks against the ```lastProcessedBlock``` to ensure that the correct quantile value can be returned.