### PR TITLE
#271 Adding functions to the bitcoin client needed for the lockmonitor.

### DIFF
--- a/lib/bitcoin/BitcoinClient.ts
+++ b/lib/bitcoin/BitcoinClient.ts
@@ -467,12 +467,14 @@ export default class BitcoinClient {
     const payToScriptHashOutput = Script.buildScriptHashOut(freezeScript);
     const payToScriptAddress = new Address(payToScriptHashOutput);
 
-    const freezeTransaction = await this.createSpendTransactionFromFrozenTransaction(
+    // We are creating a spend transaction and are paying to another freeze script.
+    // So essentially we are re-freezing ...
+    const reFreezeTransaction = await this.createSpendTransactionFromFrozenTransaction(
       previousFreezeTransaction,
       previousFreezeUntilBlock,
       payToScriptAddress);
 
-    return [freezeTransaction, freezeScript.toHex()];
+    return [reFreezeTransaction, freezeScript.toHex()];
   }
 
   private async createSpendToWalletTransaction (

--- a/lib/bitcoin/BitcoinClient.ts
+++ b/lib/bitcoin/BitcoinClient.ts
@@ -21,7 +21,6 @@ export default class BitcoinClient {
   private readonly walletPrivateKey: PrivateKey;
   private readonly walletAddress: Address;
   private readonly walletPublicKeyAsBuffer: Buffer;
-  private readonly walletPublicKeyHash: string;
 
   constructor (
     private bitcoinPeerUri: string,
@@ -42,9 +41,6 @@ export default class BitcoinClient {
 
     const walletPublicKey = this.walletPrivateKey.toPublicKey();
     this.walletPublicKeyAsBuffer = walletPublicKey.toBuffer();
-
-    const walletPublicKeyHashAsBuffer = crypto.Hash.sha256ripemd160(this.walletPublicKeyAsBuffer);
-    this.walletPublicKeyHash = walletPublicKeyHashAsBuffer.toString('hex');
 
     if (bitcoinRpcUsername && bitcoinRpcPassword) {
       this.bitcoinAuthorization = Buffer.from(`${bitcoinRpcUsername}:${bitcoinRpcPassword}`).toString('base64');
@@ -310,13 +306,6 @@ export default class BitcoinClient {
     const outputSatoshiSum = transactionOutputs.reduce((sum, value) => sum + value, 0);
 
     return (inputSatoshiSum - outputSatoshiSum);
-  }
-
-  /**
-   * Gets the wallet public key hash as it is presented in a pay-to-publick-key-hash transaction.
-   */
-  public getWalletPublicKeyHash (): string {
-    return this.walletPublicKeyHash;
   }
 
   private async addWatchOnlyAddressToWallet (publicKeyAsHex: string, rescan: boolean): Promise<void> {

--- a/lib/bitcoin/BitcoinClient.ts
+++ b/lib/bitcoin/BitcoinClient.ts
@@ -20,6 +20,8 @@ export default class BitcoinClient {
   /** Wallet private key */
   private readonly walletPrivateKey: PrivateKey;
   private readonly walletAddress: Address;
+  private readonly walletPublicKeyAsBuffer: Buffer;
+  private readonly walletPublicKeyHash: string;
 
   constructor (
     private bitcoinPeerUri: string,
@@ -38,6 +40,12 @@ export default class BitcoinClient {
 
     this.walletAddress = this.walletPrivateKey.toAddress();
 
+    const walletPublicKey = this.walletPrivateKey.toPublicKey();
+    this.walletPublicKeyAsBuffer = walletPublicKey.toBuffer();
+
+    const walletPublicKeyHashAsBuffer = crypto.Hash.sha256ripemd160(this.walletPublicKeyAsBuffer);
+    this.walletPublicKeyHash = walletPublicKeyHashAsBuffer.toString('hex');
+
     if (bitcoinRpcUsername && bitcoinRpcPassword) {
       this.bitcoinAuthorization = Buffer.from(`${bitcoinRpcUsername}:${bitcoinRpcPassword}`).toString('base64');
     }
@@ -52,7 +60,7 @@ export default class BitcoinClient {
     if (!await this.isAddressAddedToWallet(this.walletAddress.toString())) {
       console.debug(`Configuring bitcoin peer to watch address ${this.walletAddress}. This can take up to 10 minutes.`);
 
-      const publicKeyAsHex = this.walletPrivateKey.toPublicKey().toBuffer().toString('hex');
+      const publicKeyAsHex = this.walletPublicKeyAsBuffer.toString('hex');
       await this.addWatchOnlyAddressToWallet(publicKeyAsHex, true);
     } else {
       console.debug('Wallet found.');
@@ -99,18 +107,12 @@ export default class BitcoinClient {
    * @param bitcoinLockTransaction The transaction object.
    */
   public async broadcastLockTransaction (bitcoinLockTransaction: BitcoinLockTransactionModel): Promise<string> {
-    if (!(bitcoinLockTransaction.transactionObject instanceof Transaction)) {
-      throw new Error('Transaction property is not of bitcore-lib.Transaction');
-    }
 
-    const transaction: Transaction = bitcoinLockTransaction.transactionObject;
-    const rawTransaction = transaction.serialize();
-
-    return this.broadcastTransactionRpc(rawTransaction);
+    return this.broadcastTransactionRpc(bitcoinLockTransaction.serializedTransactionObject);
   }
 
   /**
-   * Creates (and NOT broadcast) a lock transaction using the funds for the linked wallet.
+   * Creates (and NOT broadcasts) a lock transaction using the funds from the linked wallet.
    *
    * NOTE: if the linked wallet outputs are spent then this transaction cannot be broadcasted. So broadcast
    * this transaction before spending from the wallet.
@@ -125,8 +127,54 @@ export default class BitcoinClient {
 
     return {
       transactionId: freezeTransaction.id,
-      redeemScript: redeemScriptAsHex,
-      transactionObject: freezeTransaction
+      transactionFee: freezeTransaction.getFee(),
+      redeemScriptAsHex: redeemScriptAsHex,
+      serializedTransactionObject: freezeTransaction.serialize()
+    };
+  }
+
+  /**
+   * Creates (and NOT broadcasts) a lock transaction using the funds from the previously locked transaction.
+   *
+   * @param existingLockTransactionId The existing transaction with locked output.
+   * @param existingLockUntilBlock The block when the output becomes spendable.
+   * @param newLockUntilBlock The new target block for locking (the amount becomes spendable at this block).
+   */
+  public async createRelockTransaction (
+    existingLockTransactionId: string,
+    existingLockUntilBlock: number,
+    newLockUntilBlock: number): Promise<BitcoinLockTransactionModel> {
+
+    const existingLockTransaction = await this.getRawTransactionRpc(existingLockTransactionId);
+
+    const [freezeTransaction, redeemScriptAsHex] =
+      await this.createSpendToFreezeTransaction(existingLockTransaction, existingLockUntilBlock, newLockUntilBlock);
+
+    return {
+      transactionId: freezeTransaction.id,
+      transactionFee: freezeTransaction.getFee(),
+      redeemScriptAsHex: redeemScriptAsHex,
+      serializedTransactionObject: freezeTransaction.serialize()
+    };
+  }
+
+  /**
+   * Creates (and NOT broadcasts) a transaction which outputs the previously locked amount into the linked
+   * wallet.
+   *
+   * @param existingLockTransactionId The existing transaction with locked amount.
+   * @param existingLockUntilBlock The block when the amount becomes spendable.
+   */
+  public async createReleaseLockTransaction (existingLockTransactionId: string, existingLockUntilBlock: number): Promise<BitcoinLockTransactionModel> {
+    const existingLockTransaction = await this.getRawTransactionRpc(existingLockTransactionId);
+
+    const releaseLockTransaction = await this.createSpendToWalletTransaction(existingLockTransaction, existingLockUntilBlock);
+
+    return {
+      transactionId: releaseLockTransaction.id,
+      transactionFee: releaseLockTransaction.getFee(),
+      redeemScriptAsHex: '',
+      serializedTransactionObject: releaseLockTransaction.serialize()
     };
   }
 
@@ -264,6 +312,13 @@ export default class BitcoinClient {
     return (inputSatoshiSum - outputSatoshiSum);
   }
 
+  /**
+   * Gets the wallet public key hash as it is presented in a pay-to-publick-key-hash transaction.
+   */
+  public getWalletPublicKeyHash (): string {
+    return this.walletPublicKeyHash;
+  }
+
   private async addWatchOnlyAddressToWallet (publicKeyAsHex: string, rescan: boolean): Promise<void> {
     const request = {
       method: 'importpubkey',
@@ -331,6 +386,12 @@ export default class BitcoinClient {
    * @param transactionId The target transaction id.
    */
   public async getRawTransaction (transactionId: string): Promise<BitcoinTransactionModel> {
+    const bitcoreTransaction = await this.getRawTransactionRpc(transactionId);
+
+    return BitcoinClient.createBitcoinTransactionModel(bitcoreTransaction);
+  }
+
+  private async getRawTransactionRpc (transactionId: string): Promise<Transaction> {
     const request = {
       method: 'getrawtransaction',
       params: [
@@ -342,9 +403,7 @@ export default class BitcoinClient {
     const hexEncodedTransaction = await this.rpcCall(request, true);
     const transactionBuffer = Buffer.from(hexEncodedTransaction, 'hex');
 
-    const bitcoreTransaction = BitcoinClient.createTransactionFromBuffer(transactionBuffer);
-
-    return BitcoinClient.createBitcoinTransactionModel(bitcoreTransaction);
+    return BitcoinClient.createTransactionFromBuffer(transactionBuffer);
   }
 
   // This function is specifically created to help with unit testing.
@@ -410,23 +469,23 @@ export default class BitcoinClient {
     return [freezeTransaction, freezeScript.toHex()];
   }
 
-  // @ts-ignore
   private async createSpendToFreezeTransaction (
     previousFreezeTransaction: Transaction,
     previousFreezeUntilBlock: number,
-    freezeUntilBlock: number): Promise<Transaction> {
+    freezeUntilBlock: number): Promise<[Transaction, string]> {
 
     const freezeScript = BitcoinClient.createFreezeScript(freezeUntilBlock, this.walletAddress);
     const payToScriptHashOutput = Script.buildScriptHashOut(freezeScript);
     const payToScriptAddress = new Address(payToScriptHashOutput);
 
-    return this.createSpendTransactionFromFrozenTransaction(
+    const freezeTransaction = await this.createSpendTransactionFromFrozenTransaction(
       previousFreezeTransaction,
       previousFreezeUntilBlock,
       payToScriptAddress);
+
+    return [freezeTransaction, freezeScript.toHex()];
   }
 
-  // @ts-ignore
   private async createSpendToWalletTransaction (
     previousFreezeTransaction: Transaction,
     previousFreezeUntilBlock: number): Promise<Transaction> {
@@ -437,7 +496,6 @@ export default class BitcoinClient {
       this.walletAddress);
   }
 
-  // @ts-ignore
   /**
    * Creates a spend transaction to spend the previously frozen output. The details
    * on how to create a spend transactions were taken from the BIP65 demo at:
@@ -484,7 +542,7 @@ export default class BitcoinClient {
     // Create a script and add it to the input.
     const inputScript = Script.empty()
                               .add(signature.toTxFormat())
-                              .add(this.walletPrivateKey.toPublicKey().toBuffer())
+                              .add(this.walletPublicKeyAsBuffer)
                               .add(previousFreezeScript.toBuffer());
 
     (spendTransaction.inputs[0] as any).setScript(inputScript);

--- a/lib/bitcoin/models/BitcoinLockTransactionModel.ts
+++ b/lib/bitcoin/models/BitcoinLockTransactionModel.ts
@@ -3,6 +3,7 @@
  */
 export default interface BitcoinLockTransactionModel {
   transactionId: string;
-  redeemScript: string;
-  transactionObject: any;
+  transactionFee: number;
+  redeemScriptAsHex: string;
+  serializedTransactionObject: string;
 }

--- a/tests/bitcoin/BitcoinClient.spec.ts
+++ b/tests/bitcoin/BitcoinClient.spec.ts
@@ -14,7 +14,6 @@ describe('BitcoinClient', async () => {
   let bitcoinWalletImportString: string;
   let privateKeyFromBitcoinClient: PrivateKey;
   let walletAddressFromBitcoinClient: Address;
-  let walletPublicKeyHashFromBitcoinClient: string;
 
   const bitcoinPeerUri = 'uri:someuri/';
   const maxRetries = 2;
@@ -25,7 +24,6 @@ describe('BitcoinClient', async () => {
 
     privateKeyFromBitcoinClient = bitcoinClient['walletPrivateKey'];
     walletAddressFromBitcoinClient = bitcoinClient['walletAddress'];
-    walletPublicKeyHashFromBitcoinClient = bitcoinClient['walletPublicKeyHash'];
 
     // this is always mocked to protect against actual calls to the bitcoin network
     fetchSpy = spyOn(nodeFetchPackage, 'default');
@@ -368,14 +366,6 @@ describe('BitcoinClient', async () => {
 
       const actual = await bitcoinClient.getTransactionFeeInSatoshis('someid');
       expect(actual).toEqual(mockInputsSum - mockTxnOutputsSum);
-    });
-  });
-
-  describe('getWalletPublicKeyHash', () => {
-    it('should return the correct value.', async (done) => {
-      const actual = bitcoinClient.getWalletPublicKeyHash();
-      expect(actual).toEqual(walletPublicKeyHashFromBitcoinClient);
-      done();
     });
   });
 

--- a/tests/bitcoin/BitcoinClient.spec.ts
+++ b/tests/bitcoin/BitcoinClient.spec.ts
@@ -14,6 +14,7 @@ describe('BitcoinClient', async () => {
   let bitcoinWalletImportString: string;
   let privateKeyFromBitcoinClient: PrivateKey;
   let walletAddressFromBitcoinClient: Address;
+  let walletPublicKeyHashFromBitcoinClient: string;
 
   const bitcoinPeerUri = 'uri:someuri/';
   const maxRetries = 2;
@@ -24,6 +25,7 @@ describe('BitcoinClient', async () => {
 
     privateKeyFromBitcoinClient = bitcoinClient['walletPrivateKey'];
     walletAddressFromBitcoinClient = bitcoinClient['walletAddress'];
+    walletPublicKeyHashFromBitcoinClient = bitcoinClient['walletPublicKeyHash'];
 
     // this is always mocked to protect against actual calls to the bitcoin network
     fetchSpy = spyOn(nodeFetchPackage, 'default');
@@ -95,8 +97,9 @@ describe('BitcoinClient', async () => {
       const transaction = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString);
       const mockInputTxnModel: BitcoinLockTransactionModel = {
         transactionId: 'some txn id',
-        redeemScript: 'some-redeem-script',
-        transactionObject: transaction
+        transactionFee: 100,
+        redeemScriptAsHex: 'some-redeem-script',
+        serializedTransactionObject: transaction.toString()
       };
 
       const transactionToString = transaction.toString();
@@ -110,29 +113,12 @@ describe('BitcoinClient', async () => {
       expect(spy).toHaveBeenCalledWith(transactionToString);
       done();
     });
-
-    it('should throw if the input object does not have the expected Transaction object.', async (done) => {
-
-      const mockInputTxnModel: BitcoinLockTransactionModel = {
-        transactionId: 'some txn id',
-        redeemScript: 'some-redeem-script',
-        transactionObject: { key: 'some input' }
-      };
-
-      try {
-        await bitcoinClient.broadcastLockTransaction(mockInputTxnModel);
-        fail('expected exception to be thrown');
-      } catch (e) {
-        expect(e.message).toContain('bitcore-lib.Transaction');
-      }
-
-      done();
-    });
   });
 
   describe('createLockTransaction', () => {
     it('should create the lock transaction.', async () => {
       const mockFreezeTxn = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString);
+      const mockFreezeTxnToString = mockFreezeTxn.toString();
       const mockRedeemScript = 'some redeem script';
 
       const mockUnspentOutput = BitcoinDataGenerator.generateUnspentCoin(bitcoinWalletImportString, 1233423426);
@@ -140,6 +126,7 @@ describe('BitcoinClient', async () => {
 
       const mockCreateFreezeTxnOutput = [mockFreezeTxn, mockRedeemScript];
       const createFreezeTxnSpy = spyOn(bitcoinClient as any, 'createFreezeTransaction').and.returnValue(Promise.resolve(mockCreateFreezeTxnOutput));
+      spyOn(mockFreezeTxn, 'serialize').and.returnValue(mockFreezeTxnToString);
 
       const lockAmountInput = 123456;
       const lockUntilBlockInput = 789005;
@@ -148,12 +135,71 @@ describe('BitcoinClient', async () => {
 
       const expectedOutput: BitcoinLockTransactionModel = {
         transactionId: mockFreezeTxn.id,
-        redeemScript: mockRedeemScript,
-        transactionObject: mockFreezeTxn
+        transactionFee: mockFreezeTxn.getFee(),
+        redeemScriptAsHex: mockRedeemScript,
+        serializedTransactionObject: mockFreezeTxnToString
       };
       expect(actual).toEqual(expectedOutput);
 
       expect(createFreezeTxnSpy).toHaveBeenCalledWith([mockUnspentOutput], lockUntilBlockInput, lockAmountInput);
+    });
+  });
+
+  describe('createRelockTransaction', () => {
+    it('should create the relock transaction.', async () => {
+      const mockFreezeTxn = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString);
+      const mockFreezeTxnToString = mockFreezeTxn.toString();
+
+      const mockPreviousFreezeTxn = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString);
+      const mockRedeemScript = 'some redeem script';
+
+      const mockCreateFreezeTxnOutput = [mockFreezeTxn, mockRedeemScript];
+      const createFreezeTxnSpy = spyOn(bitcoinClient as any, 'createSpendToFreezeTransaction').and.returnValue(Promise.resolve(mockCreateFreezeTxnOutput));
+
+      spyOn(bitcoinClient as any, 'getRawTransactionRpc').and.returnValue(Promise.resolve(mockPreviousFreezeTxn));
+      spyOn(mockFreezeTxn, 'serialize').and.returnValue(mockFreezeTxnToString);
+
+      const existingLockBlockInput = 123456;
+      const lockUntilBlockInput = 789005;
+
+      const actual = await bitcoinClient.createRelockTransaction('previousFreezeTxnId', existingLockBlockInput, lockUntilBlockInput);
+
+      const expectedOutput: BitcoinLockTransactionModel = {
+        transactionId: mockFreezeTxn.id,
+        transactionFee: mockFreezeTxn.getFee(),
+        redeemScriptAsHex: mockRedeemScript,
+        serializedTransactionObject: mockFreezeTxnToString
+      };
+      expect(actual).toEqual(expectedOutput);
+
+      expect(createFreezeTxnSpy).toHaveBeenCalledWith(mockPreviousFreezeTxn, existingLockBlockInput, lockUntilBlockInput);
+    });
+  });
+
+  describe('createReleaseLockTransaction', () => {
+    it('should create the relock transaction.', async () => {
+      const mockFreezeTxn = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString);
+      const mockFreezeTxnToString = mockFreezeTxn.toString();
+      const mockPreviousFreezeTxn = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString);
+
+      const createBack2WalletTxnSpy = spyOn(bitcoinClient as any, 'createSpendToWalletTransaction').and.returnValue(Promise.resolve(mockFreezeTxn));
+
+      spyOn(bitcoinClient as any, 'getRawTransactionRpc').and.returnValue(Promise.resolve(mockPreviousFreezeTxn));
+      spyOn(mockFreezeTxn, 'serialize').and.returnValue(mockFreezeTxnToString);
+
+      const existingLockBlockInput = 123456;
+
+      const actual = await bitcoinClient.createReleaseLockTransaction('previousFreezeTxnId', existingLockBlockInput);
+
+      const expectedOutput: BitcoinLockTransactionModel = {
+        transactionId: mockFreezeTxn.id,
+        transactionFee: mockFreezeTxn.getFee(),
+        redeemScriptAsHex: '',
+        serializedTransactionObject: mockFreezeTxnToString
+      };
+      expect(actual).toEqual(expectedOutput);
+
+      expect(createBack2WalletTxnSpy).toHaveBeenCalledWith(mockPreviousFreezeTxn, existingLockBlockInput);
     });
   });
 
@@ -244,12 +290,25 @@ describe('BitcoinClient', async () => {
       const mockTransaction: Transaction = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString, 50);
       const mockTransactionAsOutputTxn = BitcoinClient['createBitcoinTransactionModel'](mockTransaction);
 
+      const spy = spyOn(bitcoinClient as any, 'getRawTransactionRpc').and.returnValue(mockTransaction);
+
+      const actual = await bitcoinClient.getRawTransaction(txnId);
+      expect(actual).toEqual(mockTransactionAsOutputTxn);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('getRawTransactionRpc', () => {
+    it('should make the correct rpc call and return the transaction object', async () => {
+      const txnId = 'transaction_id';
+      const mockTransaction: Transaction = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString, 50);
+
       spyOn(BitcoinClient as any, 'createTransactionFromBuffer').and.returnValue(mockTransaction);
 
       const spy = mockRpcCall('getrawtransaction', [txnId, 0], mockTransaction.toString());
 
-      const actual = await bitcoinClient.getRawTransaction(txnId);
-      expect(actual).toEqual(mockTransactionAsOutputTxn);
+      const actual = await bitcoinClient['getRawTransactionRpc'](txnId);
+      expect(actual).toEqual(mockTransaction);
       expect(spy).toHaveBeenCalled();
     });
   });
@@ -309,6 +368,14 @@ describe('BitcoinClient', async () => {
 
       const actual = await bitcoinClient.getTransactionFeeInSatoshis('someid');
       expect(actual).toEqual(mockInputsSum - mockTxnOutputsSum);
+    });
+  });
+
+  describe('getWalletPublicKeyHash', () => {
+    it('should return the correct value.', async (done) => {
+      const actual = bitcoinClient.getWalletPublicKeyHash();
+      expect(actual).toEqual(walletPublicKeyHashFromBitcoinClient);
+      done();
     });
   });
 
@@ -476,8 +543,10 @@ describe('BitcoinClient', async () => {
       const createScriptSpy = spyOn(BitcoinClient as any, 'createFreezeScript').and.returnValue(mockRedeemScript);
       const utilFuncSpy = spyOn(bitcoinClient as any, 'createSpendTransactionFromFrozenTransaction').and.returnValue(mockFreezeTxn2);
 
-      const actual = await bitcoinClient['createSpendToFreezeTransaction'](mockFreezeTxn1, mockFreezeUntilPreviousBlock, mockFreezeUntilBlock);
-      expect(actual).toEqual(mockFreezeTxn2);
+      // tslint:disable-next-line: max-line-length
+      const [actualTxn, redeemScript] = await bitcoinClient['createSpendToFreezeTransaction'](mockFreezeTxn1, mockFreezeUntilPreviousBlock, mockFreezeUntilBlock);
+      expect(actualTxn).toEqual(mockFreezeTxn2);
+      expect(redeemScript).toEqual(mockRedeemScript.toHex());
       expect(createScriptSpy).toHaveBeenCalledWith(mockFreezeUntilBlock, walletAddressFromBitcoinClient);
 
       const expectedPayToScriptAddress = new Address(mockRedeemScriptHashOutput);
@@ -872,5 +941,4 @@ describe('BitcoinClient', async () => {
       done();
     }, 500);
   });
-
 });


### PR DESCRIPTION
Added following functionality to the BitcoinClient for the lock monitor changes coming next:
1. Functions to create lock, relock, and releaselock transactions.
1. Function to broadcast the lock transactions.
1. Function to return the public key hash of the wallet.

Also, added a couple of fields to the BitcoinLockTransactionModel object.