### PR TITLE
Remove all TODOs without a github issue reference in code

### DIFF
--- a/lib/ipfs/@types/ipfs/index.d.ts
+++ b/lib/ipfs/@types/ipfs/index.d.ts
@@ -108,12 +108,10 @@ declare namespace IPFS {
       path (): string;
     }
 
-    // TODO: Add type for pull-stream
     export type FileContent = Buffer | NodeJS.ReadableStream | Files[];
 
     export interface Files {
       path: string;
-        // TODO: Add type for pull-stream
       content?: Buffer | NodeJS.ReadableStream;
     }
 


### PR DESCRIPTION
In response to #159 

There were only two such occurrences that I found (referencing the same task). Let me know if you would rather me leave the TODOs, create an issue to track it, and put the link in the comments.