### PR TITLE
#425 - Make ipfs request handler follow constructor/initialize pattern

### DIFF
--- a/lib/ipfs/ErrorCode.ts
+++ b/lib/ipfs/ErrorCode.ts
@@ -1,4 +1,5 @@
 export default {
   IpfsStorageInstanceCanOnlyBeCreatedOnce: 'ipfs_storage_instance_can_only_be_created_once',
-  IpfsStorageInstanceGetHasToBeCalledAfterCreate: 'ipfs_storage_instance_get_has_to_be_called_after_create'
+  IpfsStorageInstanceGetHasToBeCalledAfterCreate: 'ipfs_storage_instance_get_has_to_be_called_after_create',
+  RequestHandlerIpfsStorageInstanceGetHasToBeCalledAfterInitialize: 'request_handler_ipfs_storage_instance_get_has_to_be_called_after_initialize'
 };

--- a/tests/ipfs/RequestHandler.spec.ts
+++ b/tests/ipfs/RequestHandler.spec.ts
@@ -11,8 +11,20 @@ describe('RequestHandler', async () => {
   beforeAll(async (done) => {
     maxFileSize = 20000000; // 20MB
     fetchTimeoutInSeconds = 1;
-    requestHandler = await RequestHandler.create(fetchTimeoutInSeconds);
+    requestHandler = new RequestHandler(fetchTimeoutInSeconds);
+    await requestHandler.initialize();
     done();
+  });
+
+  it('should throw if RequestHandler\'s ipfsStorage has not been initialized', async () => {
+    let uninitializedHandler = new RequestHandler(1);
+    try {
+      // @ts-ignore: Variable never used because error should be thrown.
+      let x = uninitializedHandler.ipfsStorage;
+      fail('should have thrown');
+    } catch (error) {
+      expect(error.message).toContain('initialize()');
+    }
   });
 
   it('should return the correct response object for invalid multihash for fetch request.', async () => {


### PR DESCRIPTION
In response to #425 

New to js/ts so please correct me if I misused the definite assignment assertion operator on the `RequestHandler.ipfsStorage` property. Wasn't sure if `!` should be used or if it should have just been declared as `ipfsStorage: IpfsStorage | undefined` to force the caller to make sure `intialize()` was invoked.