### PR TITLE
#434 - Remove 2 calls to sidetree transaction parser parse

### DIFF
--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -612,10 +612,11 @@ export default class BitcoinProcessor {
   }
 
   /**
-   * Given a Bitcoin block, filter down to and return all potential sidetree transactions
+   * Filter the given bitcoin block into sidetree and non-sidetree transactions
    * @param blockHeight Block height to process
    * @param blockData Block data to process
-   * @returns an array of sidetree TransactionModels and an array of non-sidetree BitcoinTransactionModels
+   * @returns an array of sidetree TransactionModels and an array of non-sidetree BitcoinTransactionModels (coinbase
+   * transaction omitted)
    */
   private async filterBlock (blockHeight: number, blockData: BitcoinBlockModel): Promise<[TransactionModel[], BitcoinTransactionModel[]]> {
     const transactions = blockData.transactions;

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -656,10 +656,9 @@ export default class BitcoinProcessor {
     // reseed source of psuedo-randomness to the blockhash
     this.transactionSampler.resetPsuedoRandomSeed(blockHash);
 
-    // First transaction in a block is always the coinbase (miner's) transaction and has no inputs
-    // so we are going to ignore that transaction in our calculations.
-    for (let transactionIndex = 1; transactionIndex < nonSidetreeTransactions.length; transactionIndex++) {
-      const transaction = nonSidetreeTransactions[transactionIndex];
+    // Assume coinbase tx is not included in the non-sidetree transactions, so we iterate from 0
+    for (let i = 0; i < nonSidetreeTransactions.length; i++) {
+      const transaction = nonSidetreeTransactions[i];
 
       // Filter out transactions with unusual input count - such transaction require a large number of
       // rpc calls to compute transaction fee not worth the cost for an approximate measure.

--- a/tests/bitcoin/BitcoinProcessor.spec.ts
+++ b/tests/bitcoin/BitcoinProcessor.spec.ts
@@ -1325,7 +1325,7 @@ describe('BitcoinProcessor', () => {
         // tslint:disable-next-line: max-line-length
         { anchorString: 'anchor2', transactionTimeHash: 'timehash2', transactionTime: 150, transactionNumber: 250, transactionFeePaid: 350, normalizedTransactionFee: 450, writer: 'writer2' }
       ];
-      const mockNonSidetreeTransactions: BitcoinTransactionModel[] = [blockData.transactions[3]];
+      const mockNonSidetreeTransactions: BitcoinTransactionModel[] = [blockData.transactions[2]];
 
       const filterBlockSpy = spyOn(bitcoinProcessor, 'filterBlock' as any).and.returnValue(
           Promise.resolve([mockSidetreeTransactions, mockNonSidetreeTransactions])

--- a/tests/bitcoin/BitcoinProcessor.spec.ts
+++ b/tests/bitcoin/BitcoinProcessor.spec.ts
@@ -1506,7 +1506,7 @@ describe('BitcoinProcessor', () => {
         writer: mockSidetreeData.writer
       };
 
-      const output = await bitcoinProcessor['getTransactionModel'](mockSidetreeData, mockTxn, 10, mockTxnBlock);
+      const output = await bitcoinProcessor['getTransactionModelIfExist'](mockTxn, 10, mockTxnBlock);
       expect(output).toBeDefined();
       expect(output).toEqual(mockOutputTxnModel);
       expect(getTxnFeeSpy).toHaveBeenCalled();


### PR DESCRIPTION
In response to #434 

Change flow of `bitcoinProcessor.processBlock()` such that a `bitcoinProcessor.filterBlock()` is called that returns all sidetree transactions found in the block, while performing PoF calculations on the others. After filtering, the sidetree transactions are added to the transaction store. The `sidetreeTransactionParser.Parse()` function is now only called once per tx in `bitcoinProcessor.filterBlock()`

Certainly open to feedback if this is off-base from what the issue was aiming to achieve!