### PR TITLE
spec: make public key context generic

### DIFF
--- a/docs/spec/markdown/context.md
+++ b/docs/spec/markdown/context.md
@@ -22,7 +22,7 @@ Deprecated. DO NOT USE.
 
 ### publicKeyJwk
 
-A secp256k1 public key in JWK format. A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. Read [RFC7517](https://tools.ietf.org/html/rfc7517).
+A public key in JWK format. A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. Read [RFC7517](https://tools.ietf.org/html/rfc7517).
 
 Example:
 
@@ -42,7 +42,7 @@ Example:
 
 ### publicKeyHex
 
-A hex encoded secp256k1 compressed public key.
+A hex encoded compressed public key.
 
 Example:
 


### PR DESCRIPTION
Generalizes publicKeyJwk to not be specific to secp256k1