### PR TITLE
Should not store complex operation objects in DB

### DIFF
--- a/lib/core/versions/latest/AnchorFile.ts
+++ b/lib/core/versions/latest/AnchorFile.ts
@@ -17,7 +17,7 @@ import SidetreeError from '../../../common/SidetreeError';
 export default class AnchorFile {
 
   /**
-   * Class that represends an anchor file.
+   * Class that represents an anchor file.
    * NOTE: this class is introduced as an internal structure in replacement to `AnchorFileModel`
    * to keep useful metadata so that repeated computation can be avoided.
    */

--- a/lib/core/versions/latest/MapFile.ts
+++ b/lib/core/versions/latest/MapFile.ts
@@ -11,7 +11,7 @@ import UpdateOperation from './UpdateOperation';
  */
 export default class MapFile {
   /**
-   * Class that represents map file.
+   * Class that represents a map file.
    * NOTE: this class is introduced as an internal structure in replacement to `MapFileModel`
    * to keep useful metadata so that repeated computation can be avoided.
    */

--- a/lib/core/versions/latest/MapFile.ts
+++ b/lib/core/versions/latest/MapFile.ts
@@ -11,10 +11,20 @@ import UpdateOperation from './UpdateOperation';
  */
 export default class MapFile {
   /**
+   * Class that represents map file.
+   * NOTE: this class is introduced as an internal structure in replacement to `MapFileModel`
+   * to keep useful metadata so that repeated computation can be avoided.
+   */
+  private constructor (
+    public readonly model: MapFileModel,
+    public readonly didUniqueSuffixes: string[],
+    public readonly updateOperations: UpdateOperation[]) { }
+
+  /**
    * Parses and validates the given map file buffer.
    * @throws `SidetreeError` if failed parsing or validation.
    */
-  public static async parse (mapFileBuffer: Buffer): Promise<MapFileModel> {
+  public static async parse (mapFileBuffer: Buffer): Promise<MapFile> {
 
     let decompressedBuffer;
     try {
@@ -23,42 +33,45 @@ export default class MapFile {
       throw SidetreeError.createFromError(ErrorCode.MapFileDecompressionFailure, error);
     }
 
-    let mapFile;
+    let mapFileModel;
     try {
-      mapFile = await JsonAsync.parse(decompressedBuffer);
+      mapFileModel = await JsonAsync.parse(decompressedBuffer);
     } catch (error) {
       throw SidetreeError.createFromError(ErrorCode.MapFileNotJson, error);
     }
 
     const allowedProperties = new Set(['batchFileHash', 'updateOperations']);
-    for (let property in mapFile) {
+    for (let property in mapFileModel) {
       if (!allowedProperties.has(property)) {
         throw new SidetreeError(ErrorCode.MapFileHasUnknownProperty);
       }
     }
 
-    if (typeof mapFile.batchFileHash !== 'string') {
+    if (typeof mapFileModel.batchFileHash !== 'string') {
       throw new SidetreeError(ErrorCode.MapFileBatchFileHashMissingOrIncorrectType);
     }
 
     // Validate `updateOperations` if exists.
-    const updateOperations = mapFile.updateOperations;
-    if (updateOperations !== undefined) {
-      if (!Array.isArray(updateOperations)) {
+    const updateOperations: UpdateOperation[] = [];
+    let didUniqueSuffixes: string[] = [];
+    if (mapFileModel.updateOperations !== undefined) {
+      if (!Array.isArray(mapFileModel.updateOperations)) {
         throw new SidetreeError(ErrorCode.MapFileUpdateOperationsNotArray);
       }
 
       // Validate each operation.
-      for (const operation of updateOperations) {
-        await UpdateOperation.parseOpertionFromAnchorFile(operation);
+      for (const operation of mapFileModel.updateOperations) {
+        const updateOperation = await UpdateOperation.parseOpertionFromMapFile(operation);
+        updateOperations.push(updateOperation);
       }
 
-      const didUniqueSuffixes = (mapFile as MapFileModel).updateOperations!.map(operation => operation.didUniqueSuffix);
+      didUniqueSuffixes = updateOperations.map(operation => operation.didUniqueSuffix);
       if (ArrayMethods.hasDuplicates(didUniqueSuffixes)) {
         throw new SidetreeError(ErrorCode.MapFileMultipleOperationsForTheSameDid);
       }
     }
 
+    const mapFile = new MapFile(mapFileModel, didUniqueSuffixes, updateOperations);
     return mapFile;
   }
 

--- a/lib/core/versions/latest/UpdateOperation.ts
+++ b/lib/core/versions/latest/UpdateOperation.ts
@@ -53,9 +53,9 @@ export default class UpdateOperation implements OperationModel {
   }
 
   /**
-   * Parses the given input as a recover operation entry in the anchor file.
+   * Parses the given input as an update operation entry in the map file.
    */
-  public static async parseOpertionFromAnchorFile (input: any): Promise<UpdateOperation> {
+  public static async parseOpertionFromMapFile (input: any): Promise<UpdateOperation> {
     const opertionBuffer = Buffer.from(JSON.stringify(input));
     const operation = await UpdateOperation.parseObject(input, opertionBuffer, true);
     return operation;
@@ -76,11 +76,11 @@ export default class UpdateOperation implements OperationModel {
    * The `operationBuffer` given is assumed to be valid and is assigned to the `operationBuffer` directly.
    * NOTE: This method is purely intended to be used as an optimization method over the `parse` method in that
    * JSON parsing is not required to be performed more than once when an operation buffer of an unknown operation type is given.
-   * @param anchorFileMode If set to true, then `patchData` and `type` properties are expected to be absent.
+   * @param mapFileMode If set to true, then `patchData` and `type` properties are expected to be absent.
    */
-  public static async parseObject (operationObject: any, operationBuffer: Buffer, anchorFileMode: boolean): Promise<UpdateOperation> {
+  public static async parseObject (operationObject: any, operationBuffer: Buffer, mapFileMode: boolean): Promise<UpdateOperation> {
     let expectedPropertyCount = 5;
-    if (anchorFileMode) {
+    if (mapFileMode) {
       expectedPropertyCount = 3;
     }
 
@@ -105,10 +105,10 @@ export default class UpdateOperation implements OperationModel {
 
     const signedData = Jws.parse(operationObject.signedData);
 
-    // If not in anchor file mode, we need to validate `type` and `patchData` properties.
+    // If not in map file mode, we need to validate `type` and `patchData` properties.
     let encodedPatchData = undefined;
     let patchData = undefined;
-    if (!anchorFileMode) {
+    if (!mapFileMode) {
       if (operationObject.type !== OperationType.Update) {
         throw new SidetreeError(ErrorCode.UpdateOperationTypeIncorrect);
       }

--- a/tests/core/TransactionProcessor.spec.ts
+++ b/tests/core/TransactionProcessor.spec.ts
@@ -316,7 +316,7 @@ describe('TransactionProcessor', () => {
   });
 
   describe('downloadAndVerifyMapFile', () => {
-    it('should validates the map file when the map file does declare the updateOperations property.', async (done) => {
+    it('should validates the map file when the map file does not declare the updateOperations property.', async (done) => {
       const createOperationData = await OperationGenerator.generateCreateOperation();
       const mapFileHash = OperationGenerator.generateRandomHash();
       const anchorFileBuffer = await AnchorFile.createBuffer('writerLockId', mapFileHash, [createOperationData.createOperation], [], []);
@@ -332,8 +332,8 @@ describe('TransactionProcessor', () => {
       const fetchedMapFile = await transactionProcessor['downloadAndVerifyMapFile'](anchorFile, totalPaidOperationCount);
 
       expect(fetchedMapFile).toBeDefined();
-      expect(fetchedMapFile!.updateOperations).toBeUndefined();
-      expect(fetchedMapFile!.batchFileHash).toEqual(batchFileHash);
+      expect(fetchedMapFile!.updateOperations.length).toEqual(0);
+      expect(fetchedMapFile!.model.batchFileHash).toEqual(batchFileHash);
       done();
     });
 
@@ -517,7 +517,7 @@ describe('TransactionProcessor', () => {
       const batchFileModel = await BatchFile.parse(batchFileBuffer);
 
       // Setting the total paid operation count to be 1 (needs to be at least 2 in success case).
-      const anchoredOperationModels = transactionProcessor['composeAnchoredOperationModels'](transactionModel, anchorFile, mapFileModel, batchFileModel);
+      const anchoredOperationModels = await transactionProcessor['composeAnchoredOperationModels'](transactionModel, anchorFile, mapFileModel, batchFileModel);
 
       expect(anchoredOperationModels.length).toEqual(2);
       expect(anchoredOperationModels[0].didUniqueSuffix).toEqual(createOperation.didUniqueSuffix);
@@ -547,7 +547,7 @@ describe('TransactionProcessor', () => {
       const anchorFile = await AnchorFile.parse(anchorFileBuffer);
 
       // Setting the total paid operation count to be 1 (needs to be at least 2 in success case).
-      const anchoredOperationModels = transactionProcessor['composeAnchoredOperationModels'](transactionModel, anchorFile, undefined, undefined);
+      const anchoredOperationModels = await transactionProcessor['composeAnchoredOperationModels'](transactionModel, anchorFile, undefined, undefined);
 
       expect(anchoredOperationModels.length).toEqual(1);
       expect(anchoredOperationModels[0].didUniqueSuffix).toEqual(createOperation.didUniqueSuffix);

--- a/tests/core/TransactionProcessor.spec.ts
+++ b/tests/core/TransactionProcessor.spec.ts
@@ -316,7 +316,7 @@ describe('TransactionProcessor', () => {
   });
 
   describe('downloadAndVerifyMapFile', () => {
-    it('should validates the map file when the map file does not declare the updateOperations property.', async (done) => {
+    it('should validate the map file when the map file does not declare the updateOperations property.', async (done) => {
       const createOperationData = await OperationGenerator.generateCreateOperation();
       const mapFileHash = OperationGenerator.generateRandomHash();
       const anchorFileBuffer = await AnchorFile.createBuffer('writerLockId', mapFileHash, [createOperationData.createOperation], [], []);

--- a/tests/generators/VegetaLoadGenerator.ts
+++ b/tests/generators/VegetaLoadGenerator.ts
@@ -32,7 +32,7 @@ export default class VegetaLoadGenerator {
 
       const signingKeyId = 'signingKey';
       const [signingPublicKey, signingPrivateKey] = await OperationGenerator.generateKeyPair(signingKeyId);
-      const services = OperationGenerator.generateServiceEndpoints(['serviceEndpointsId123']);
+      const services = OperationGenerator.generateServiceEndpoints(['serviceEndpointId123']);
 
       const [recover1RevealValue, recoveryCommitmentHash] = OperationGenerator.generateCommitRevealPair();
       const [, recovery2CommitmentHash] = OperationGenerator.generateCommitRevealPair();

--- a/tests/generators/vegeta.ts
+++ b/tests/generators/vegeta.ts
@@ -3,7 +3,7 @@
  */
 import VegetaLoadGenerator from './VegetaLoadGenerator';
 
-const uniqueDidCount = 20000;
+const uniqueDidCount = 10;
 const endpointUrl = 'http://localhost:3000/';
 const outputFolder = `d:/vegeta-localhost-jws`;
 

--- a/tests/generators/vegeta.ts
+++ b/tests/generators/vegeta.ts
@@ -3,7 +3,7 @@
  */
 import VegetaLoadGenerator from './VegetaLoadGenerator';
 
-const uniqueDidCount = 10;
+const uniqueDidCount = 20000;
 const endpointUrl = 'http://localhost:3000/';
 const outputFolder = `d:/vegeta-localhost-jws`;
 


### PR DESCRIPTION
Fixed the following bugs:
1. We are serializing and storing the complex operation objects as opposed to just the raw operation buffer in MongoDB.
1. The ID for service endpoints in operations generated  by load generator is too long thus get invalidated by resolver.