### PR TITLE
#519 Updating the valueTimeLockAmountMultiplier

### DIFF
--- a/lib/core/versions/latest/protocol-parameters.json
+++ b/lib/core/versions/latest/protocol-parameters.json
@@ -10,5 +10,5 @@
   "maxPatchDataSizeInBytes": 1000,
   "maxNumberOfOperationsForNoValueTimeLock": 100,
   "normalizedFeeToPerOperationFeeMultiplier": 0.01,
-  "valueTimeLockAmountMultiplier": 550
+  "valueTimeLockAmountMultiplier": 600
 }

--- a/lib/core/versions/latest/protocol-parameters.json
+++ b/lib/core/versions/latest/protocol-parameters.json
@@ -10,5 +10,5 @@
   "maxPatchDataSizeInBytes": 1000,
   "maxNumberOfOperationsForNoValueTimeLock": 100,
   "normalizedFeeToPerOperationFeeMultiplier": 0.01,
-  "valueTimeLockAmountMultiplier": 10
+  "valueTimeLockAmountMultiplier": 550
 }


### PR DESCRIPTION
The value is based on the bitcoin -> USD converter today.

Using the formula in the linked issue #519 calculated the value for the protocol parameter.

`[Satoshis equivalent to $100K] = 10000 * 25000 * 0.01 * valueTimeLockAmountMultiplier`
`valueTimeLockAmountMultiplier = [Satoshis equivalent to $100K] / 2500000`

Today $100K == 14.42 BTC (approx) == 1447188475 satoshis (approx)

Plugging in the formula above yields the value of `578`. I rounded it to `600` and using that value. This means that for max operations per batch (10K), the required lock amount == 1,500,000,000 satoshis == $103649 (approx) today.