### PR TITLE
Sidetree operations REST API spec

### DIFF
--- a/spec/markdown/rest-api.md
+++ b/spec/markdown/rest-api.md
@@ -36,3 +36,107 @@ A resolution is requested as follows:
 5. Otherwise, for failure, the server MUST respond with an appropriate HTTP Status Code (400, 401, 404, 500).
 
 ### Sidetree Operations
+
+Sidetree operation requests to the REST API consist of a type property indicating the operation to be performed along with operation-specific properties and data.
+
+::: example
+```json
+{
+    "type": OPERATION_TYPE,
+    ...
+}
+```
+:::
+
+A valid Sidetree Operation Request is a JSON document composed as follows:
+
+1. The Operation Request MUST contain a `type` property, and its value MUST be a valid operation defined in
+[File Structure](#file-structures). The defined operations are `create`, `recover`, `deactivate`, `update`.
+2. Populate additional properties according to the appropriate subsection.
+3. The client MUST POST the Operation Request JSON document to the Sidetree operation endpoint `/sidetree/operations` under the desired REST server path.
+4. The server MUST respond with HTTP status 200 when successful. Otherwise, for failure, the server MUST respond with an appropriate HTTP Status Code (400, 401, 404, 500).
+
+#### Create
+
+::: example
+```json
+{
+    "type": "create",
+    "suffix_data": SUFFIX_DATA_OBJECT,
+    "operation_data": OPERATION_DATA_OBJECT
+}
+```
+:::
+
+Use the following process to generate a Sidetree create operation JSON document for the REST API, composed as follows:
+
+1. The object MUST contain a `type` property, and its value MUST be `create`.
+2. The object MUST contain a `suffix_data` property, and its value must be a `Base64URL` encoded _Suffix Data Object_(#anchor-file-create-entry).
+3. The object MUST contain an `operation_data` property, and its value must be a `Base64URL` encoded [_Create Operation Data Object_](#create-data-object).
+
+#### Update
+
+::: example
+```json
+{
+    "type": "update",
+    "did_suffix": DID_SUFFIX,
+    "update_reveal_value": REVEAL_VALUE,
+    "operation_data": OPERATION_DATA_OBJECT,
+    "signed_data": JWS_SIGNED_VALUE
+}
+```
+:::
+
+Use the following process to generate a Sidetree update operation JSON document for the REST API, composed as follows:
+
+1. The object MUST contain a `type` property, and its value MUST be `update`.
+2. The object MUST contain a `did_suffix` property, and its value MUST be the [DID Suffix](#did-suffix) of the DID the operation pertains to.
+3. The object MUST contain a `update_reveal_value` property, and its value MUST be the last update [COMMITMENT_VALUE](#commitment-value).
+4. The object MUST contain an `operation_data` property, and its value MUST be a `Base64URL` encoded [_Update Operation Data Object_](#update-data-object).
+5. The object MUST contain a `signed_data` property, and its value MUST be a [IETF RFC 7515](https://tools.ietf.org/html/rfc7515) compliant JWS object
+as defined in [Map File](#map-file) for Update operations.
+
+#### Recover
+
+::: example
+```json
+{
+    "type": "recover",
+    "did_suffix": DID_SUFFIX,
+    "recovery_reveal_value": REVEAL_VALUE,
+    "operation_data": OPERATION_DATA_OBJECT,
+    "signed_data": JWS_SIGNED_VALUE
+}
+```
+:::
+
+Use the following process to generate a Sidetree recovery operation JSON document for the REST API, composed as follows:
+
+1. The object MUST contain a `type` property, and its value MUST be `recover`.
+2. The object MUST contain a `did_suffix` property, and its value MUST be the [DID Suffix](#did-suffix) of the DID the operation pertains to.
+3. The object MUST contain a `recovery_reveal_value` property, and its value MUST be the last recovery [COMMITMENT_VALUE](#commitment-value).
+4. The object MUST contain an `operation_data` property, and its value MUST be a `Base64URL` encoded [_Recovery Operation Data Object_](#recover-data-object).
+5. The object MUST contain a `signed_data` property, and its value MUST be a [IETF RFC 7515](https://tools.ietf.org/html/rfc7515) compliant JWS object
+as defined in [Anchor File](#anchor-file) for Recovery operations.
+
+#### Deactivate
+
+::: example
+```json
+{
+    "type": "deactivate",
+    "did_suffix": DID_SUFFIX,
+    "recovery_reveal_value": REVEAL_VALUE,
+    "signed_data": JWS_SIGNED_VALUE
+}
+```
+:::
+
+Use the following process to generate a Sidetree deactivate operation JSON document for the REST API, composed as follows:
+
+1. The object MUST contain a `type` property, and its value MUST be `deactivate`.
+2. The object MUST contain a `did_suffix` property, and its value MUST be the [DID Suffix](#did-suffix) of the DID the operation pertains to.
+3. The object MUST contain a `recovery_reveal_value` property, and its value MUST be the last recovery [COMMITMENT_VALUE](#commitment-value).
+4. The object MUST contain a `signed_data` property, and its value MUST be a [IETF RFC 7515](https://tools.ietf.org/html/rfc7515) compliant JWS object
+as defined in [Anchor File](#anchor-file) for Deactivate operations.


### PR DESCRIPTION
This PR adds the operations endpoint REST API specification. As compared to the original API:

- Path moves from `[server_url]` `/` to `[server_url]` `/sidetree/operations` (to align with the swagger).
- Underscore convention is used rather than snake-case.
- s/patchData/operation_data/g

Suggested Followups:

- suffix_data needs more clear definition (https://github.com/decentralized-identity/sidetree/issues/550).
- swagger for operations needs to be updated.
- add DID resolution to spec (not just swagger) including metadata for published flag.