### PR TITLE
Reference DID Resolution spec in REST API

### DIFF
--- a/spec/markdown/rest-api.md
+++ b/spec/markdown/rest-api.md
@@ -4,16 +4,24 @@ The following sections define the Sidetree resolution and operations endpoints. 
 
 ### Sidetree Resolution
 
-Sidetree resolution requests to the REST API consist of a DID and MAY include DID parameters.
+Sidetree resolution requests to the REST API are based on the [DID Resolution HTTP(S) binding](https://w3c-ccg.github.io/did-resolution/#bindings-https).
+Resolution requests consist of a DID and MAY include DID parameters.
 As detailed in [Resolution](#resolution), the resolution request MAY include the initial state DID parameter.
 
-The server responds with the Resolution Response Object composed of the DID Document and Method Metadata.
+The server responds with the [DID Resolution Result](https://w3c-ccg.github.io/did-resolution/#did-resolution-result) composed of the DID Document and Method Metadata.
+Sidetree defines `operationPublicKeys`, `recoveryKey` and `published` method metadata.
+   - `published` is detailed in [Published Property](#published-property).
+   - `operationPublicKeys` is an array of public key objects that include `ops` in the `usage` array. See [patch action](#add-public-keys) for more details. 
+   - `recoveryKey` is the recovery public key object.
 
 ::: example
 ```json
 {
-    "did_document": DID_DOCUMENT_OBJECT,
-    "metadata": {
+    "@context": "https://www.w3.org/ns/did-resolution/v1",
+    "didDocument": DID_DOCUMENT_OBJECT,
+    "methodMetadata": {
+        "operationPublicKeys": [OPERATION_PUBLIC_KEY_OBJECT, ...],
+        "recoveryKey": RECOVERY_PUBLIC_KEY_OBJECT,
         "published": boolean
     }
 }
@@ -27,12 +35,12 @@ A resolution is requested as follows:
    - The server MUST respond with HTTP Status Code 404.
 3. If the DID does not exist and valid initial state was provided:
    - The server MUST respond with HTTP Status Code 200.
-   - The server MUST return the initial DID document that is constructed from the initial state.
-   - The server MUST include the resolution response object `metadata` composed of a `published` property with value `false`.
+   - The server MUST include the `didDocument` property, with its value set to the initial DID document that is constructed from the initial state.
+   - The server MUST include the resolution response object `methodMetadata` composed of a `published` property with value `false`.
 4. If the DID does exist:
    - The server MUST respond with HTTP Status Code 200.
-   - The server MUST return the latest DID document.
-   - The server MUST include the resolution response object `metadata` composed of a `published` property with value `true`.
+   - The server MUST include the `didDocument` property, with its value set to the latest DID document.
+   - The server MUST include the resolution response object `methodMetadata` composed of a `published` property with value `true`.
 5. Otherwise, for failure, the server MUST respond with an appropriate HTTP Status Code (400, 401, 404, 500).
 
 ### Sidetree Operations
@@ -55,6 +63,7 @@ A valid Sidetree Operation Request is a JSON document composed as follows:
 2. Populate additional properties according to the appropriate subsection.
 3. The client MUST POST the Operation Request JSON document to the Sidetree operation endpoint `/sidetree/operations` under the desired REST server path.
 4. The server MUST respond with HTTP status 200 when successful. Otherwise, for failure, the server MUST respond with an appropriate HTTP Status Code (400, 401, 404, 500).
+   - In the case of a successful `create` operation, the server MUST return the DID Resolution Result for the DID as is detailed in [Sidetree Resolution](#sidetree-resolution).
 
 #### Create
 


### PR DESCRIPTION
- references the [DID Resolution HTTP(S) binding](https://w3c-ccg.github.io/did-resolution/#bindings-https).
- notes that the create operation also returns the DID resolution result.
- notes that method metadata also includes `operationPublicKeys` and `recoveryKey`.

Followups:
- Should we document additional details from DID Resolution binding. Examples:
  -  The server MUST include the `Content-Type` header, with the value set to `application/did+ld+json`.
- Questions posed in https://github.com/decentralized-identity/sidetree/issues/571
- Should `published` (eventually) be moved to resolverMetadata? 