### PR TITLE
#582, #583 - Removed network ID in -<method>-initial-state + used short fragments in `authentication`

### DIFF
--- a/lib/core/versions/latest/Did.ts
+++ b/lib/core/versions/latest/Did.ts
@@ -90,13 +90,19 @@ export default class Did {
     return did;
   }
 
-  private static getInitialStateFromDidString (didString: string, methodName: string): string {
+  private static getInitialStateFromDidString (didString: string, methodNameWithNetworkId: string): string {
     let didStringUrl = undefined;
     try {
       didStringUrl = new URL(didString);
     } catch {
       throw new SidetreeError(ErrorCode.DidInvalidDidString);
     }
+
+    // TODO: #470 - Support/disambiguate "network ID" in method name.
+
+    // Stripping away the potential network ID portion. e.g. 'sidetree:test' -> 'sidetree'
+    const methodName = methodNameWithNetworkId.split(':')[0];
+
     let queryParamCounter = 0;
     let initialStateValue;
 

--- a/lib/core/versions/latest/DocumentComposer.ts
+++ b/lib/core/versions/latest/DocumentComposer.ts
@@ -48,7 +48,7 @@ export default class DocumentComposer {
           publicKeys.push(didDocumentPublicKey);
           if (usageSet.has(PublicKeyUsage.Auth)) {
             // add into authentication by reference if has auth and has general
-            authentication.push(did + id);
+            authentication.push(id);
           }
         } else if (usageSet.has(PublicKeyUsage.Auth)) {
           // add into authentication by object if has auth but no general

--- a/tests/core/Did.spec.ts
+++ b/tests/core/Did.spec.ts
@@ -131,5 +131,11 @@ describe('DID', async () => {
       );
       done();
     });
+
+    it('should expect -<method-name>-initial-state URL param name to not contain network ID if method name given contains network ID.', async (done) => {
+      const initialState = (Did as any).getInitialStateFromDidString('did:sdietree:123?-sidetree-initial-state=xyz', 'sidetree:test');
+      expect(initialState).toEqual('xyz');
+      done();
+    });
   });
 });

--- a/tests/core/DocumentComposer.spec.ts
+++ b/tests/core/DocumentComposer.spec.ts
@@ -10,9 +10,9 @@ import SidetreeError from '../../lib/common/SidetreeError';
 describe('DocumentComposer', async () => {
 
   describe('transformToExternalDocument', () => {
-    it('should output the expected resolution result', async () => {
+    it('should output the expected resolution result given key(s) across all usage types.', async () => {
       const [anyRecoveryPublicKey] = await Jwk.generateEs256kKeyPair();
-      const [anySigningPublicKey] = await OperationGenerator.generateKeyPair('anySigningKey');
+      const [anySigningPublicKey] = await OperationGenerator.generateKeyPair('anySigningKey'); // All usages will be included by default.
       const [authPublicKey] = await OperationGenerator.generateKeyPair('authePbulicKey', ['auth']);
       const [, anyCommitmentHash] = OperationGenerator.generateCommitRevealPair();
       const document = {
@@ -49,7 +49,7 @@ describe('DocumentComposer', async () => {
           publicKeyJwk: { kty: 'EC', crv: 'secp256k1', x: anySigningPublicKey.jwk.x, y: anySigningPublicKey.jwk.y }
         }],
         authentication: [
-          'did:method:suffix#anySigningKey', // reference because it is a general usage key
+          '#anySigningKey', // reference because it is a general usage key
           {
             id: '#authePbulicKey', // object here because it is an auth usage only key
             controller: '',


### PR DESCRIPTION
1. #582 - Removed network ID in -<method>-initial-state.
1. #583 - Used short fragments in `authentication` when referencing keys in `publicKey`.
1. Added/changed unit tests to prevent future regression.
