### PR TITLE
Clarify reference to DID Suffix of Create operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ See the [implementation document](docs/implementation.md) for the detailed descr
 
 1. Clone the repo.
 2. Create a topic branch for your spec contributions.
-3. Add the following entry to your local repo's `.git/info/exclude` file: `docs/spec/index.html`.
+3. Add the following entry to your local repo's `.git/info/exclude` file: `spec/index.html`.
 4. run `npm install`
 5. run `npm run spec:edit`
-6. Open the generated `index.html` rendering of the spec, located in the `docs/spec/` directory, in your browser. 
-7. Modify files in the `docs/spec/markdown/` directory to make changes, which will render realtime in the `index.html` file you have open in your browser.
+6. Open the generated `index.html` rendering of the spec, located in the `spec/` directory, in your browser.
+7. Modify files in the `spec/markdown/` directory to make changes, which will render realtime in the `index.html` file you have open in your browser.
 8. When you are happy with your changes, commit to your topic branch and open a Pull Request on GitHub and reviewers will be alerted to review for a potential merge.
 
 ## Docker

--- a/spec/markdown/file-structures.md
+++ b/spec/markdown/file-structures.md
@@ -69,6 +69,7 @@ A valid [Anchor File](#anchor-file) is a JSON document that ****MUST NOT**** exc
       2. For each [Create](#create) operation to be included in the `create` array, herein referred to as [_Anchor File Create Entries_](#anchor-file-create-entry){id="anchor-file-create-entry"}, use the following process to compose and include a JSON object for each entry:
           - Each entry object must contain a `suffix_data` property, and its value ****MUST**** be a [_Create Operation Suffix Data Object_](#create-suffix-data-object).
       3. The [Anchor File](#anchor-file) ****MUST NOT**** include multiple [Create](#create) operations that produce the same [DID Suffix](#did-suffix).
+      4. In order to simplify the language, herein we will refer to the [DID Suffix](#did-suffix) produced by a [Create](#create) operation directly as its [DID Suffix](#did-suffix).
     - If there are any [Recovery](#recover) operations to be included in the Anchor File:
       1. The `operations` object ****MUST**** include a `recover` property, and its value ****MUST**** be an array.
       2. For each [Recovery](#recover) operation to be included in the `recover` array, herein referred to as [_Anchor File Recovery Entries_](#anchor-file-recovery-entry){id="anchor-file-recovery-entry"}, use the following process to compose and include entries:


### PR DESCRIPTION
We were referring to the DID Suffix of operations of any type. However,
Create operations do not have a DID Suffix (while Update, Deactivate and
Recover operations do). We defined the DID Suffix of Create operations
as the suffix that their suffix_data field produce