### PR TITLE
#563 - Updated property names for update, recover, and deactivate operation requests per spec

### DIFF
--- a/lib/core/versions/latest/DeactivateOperation.ts
+++ b/lib/core/versions/latest/DeactivateOperation.ts
@@ -8,8 +8,8 @@ import OperationType from '../../enums/OperationType';
 import SidetreeError from '../../../common/SidetreeError';
 
 interface SignedDataModel {
-  didUniqueSuffix: string;
-  recoveryRevealValue: string;
+  did_suffix: string;
+  recovery_reveal_value: string;
 }
 
 /**
@@ -90,24 +90,24 @@ export default class DeactivateOperation implements OperationModel {
       throw new SidetreeError(ErrorCode.DeactivateOperationMissingOrUnknownProperty);
     }
 
-    if (typeof operationObject.didUniqueSuffix !== 'string') {
+    if (typeof operationObject.did_suffix !== 'string') {
       throw new SidetreeError(ErrorCode.DeactivateOperationMissingOrInvalidDidUniqueSuffix);
     }
 
-    if (typeof operationObject.recoveryRevealValue !== 'string') {
+    if (typeof operationObject.recovery_reveal_value !== 'string') {
       throw new SidetreeError(ErrorCode.DeactivateOperationRecoveryRevealValueMissingOrInvalidType);
     }
 
-    if ((operationObject.recoveryRevealValue as string).length > Operation.maxEncodedRevealValueLength) {
+    if ((operationObject.recovery_reveal_value as string).length > Operation.maxEncodedRevealValueLength) {
       throw new SidetreeError(ErrorCode.DeactivateOperationRecoveryRevealValueTooLong);
     }
 
-    const recoveryRevealValue = operationObject.recoveryRevealValue;
+    const recoveryRevealValue = operationObject.recovery_reveal_value;
 
     const expectKidInHeader = false;
-    const signedDataJws = Jws.parseCompactJws(operationObject.signedData, expectKidInHeader);
+    const signedDataJws = Jws.parseCompactJws(operationObject.signed_data, expectKidInHeader);
     const signedData = await DeactivateOperation.parseSignedDataPayload(
-      signedDataJws.payload, operationObject.didUniqueSuffix, recoveryRevealValue);
+      signedDataJws.payload, operationObject.did_suffix, recoveryRevealValue);
 
     // If not in anchor file mode, we need to validate `type` property.
     if (!anchorFileMode) {
@@ -118,7 +118,7 @@ export default class DeactivateOperation implements OperationModel {
 
     return new DeactivateOperation(
       operationBuffer,
-      operationObject.didUniqueSuffix,
+      operationObject.did_suffix,
       recoveryRevealValue,
       signedDataJws,
       signedData
@@ -136,11 +136,11 @@ export default class DeactivateOperation implements OperationModel {
       throw new SidetreeError(ErrorCode.DeactivateOperationSignedDataMissingOrUnknownProperty);
     }
 
-    if (signedData.didUniqueSuffix !== expectedDidUniqueSuffix) {
+    if (signedData.did_suffix !== expectedDidUniqueSuffix) {
       throw new SidetreeError(ErrorCode.DeactivateOperationSignedDidUniqueSuffixMismatch);
     }
 
-    if (signedData.recoveryRevealValue !== expectedRecoveryRevealValue) {
+    if (signedData.recovery_reveal_value !== expectedRecoveryRevealValue) {
       throw new SidetreeError(ErrorCode.DeactivateOperationSignedRecoveryRevealValueMismatch);
     }
 

--- a/lib/core/versions/latest/DocumentComposer.ts
+++ b/lib/core/versions/latest/DocumentComposer.ts
@@ -108,11 +108,11 @@ export default class DocumentComposer {
    */
   public static async applyUpdateOperation (operation: UpdateOperation, document: any): Promise<any> {
     // The current document must contain the public key mentioned in the operation ...
-    const publicKey = Document.getPublicKey(document, operation.signedData.kid);
+    const publicKey = Document.getPublicKey(document, operation.signedDataJws.kid);
     DocumentComposer.validateOperationKey(publicKey);
 
     // Verify the signature.
-    if (!(await operation.signedData.verifySignature(publicKey!.jwk))) {
+    if (!(await operation.signedDataJws.verifySignature(publicKey!.jwk))) {
       throw new SidetreeError(ErrorCode.DocumentComposerInvalidSignature);
     }
 

--- a/lib/core/versions/latest/ErrorCode.ts
+++ b/lib/core/versions/latest/ErrorCode.ts
@@ -137,6 +137,7 @@ export default {
   TransactionsNotInSameBlock: 'transactions_not_in_same_block',
   UpdateOperationMissingDidUniqueSuffix: 'update_operation_missing_did_unique_suffix',
   UpdateOperationMissingOrUnknownProperty: 'update_operation_missing_or_unknown_property',
+  UpdateOperationSignedDataHasMissingOrUnknownProperty: 'update_operation_signed_data_has_missing_or_unknown_property',
   UpdateOperationTypeIncorrect: 'update_operation_type_incorrect',
   UpdateOperationUpdateRevealValueMissingOrInvalidType: 'update_operation_update_reveal_value_missing_or_invalid_type',
   UpdateOperationUpdateRevealValueTooLong: 'update_operation_update_reveal_value_too_long',

--- a/lib/core/versions/latest/MapFile.ts
+++ b/lib/core/versions/latest/MapFile.ts
@@ -83,7 +83,7 @@ export default class MapFile {
       return {
         did_suffix: operation.didUniqueSuffix,
         update_reveal_value: operation.updateRevealValue,
-        signed_data: operation.signedData.toCompactJws()
+        signed_data: operation.signedDataJws.toCompactJws()
       };
     });
 

--- a/lib/core/versions/latest/MapFile.ts
+++ b/lib/core/versions/latest/MapFile.ts
@@ -81,9 +81,9 @@ export default class MapFile {
   public static async createBuffer (batchFileHash: string, updateOperationArray: UpdateOperation[]): Promise<Buffer> {
     const updateOperations = updateOperationArray.map(operation => {
       return {
-        didUniqueSuffix: operation.didUniqueSuffix,
-        updateRevealValue: operation.updateRevealValue,
-        signedData: operation.signedData.toCompactJws()
+        did_suffix: operation.didUniqueSuffix,
+        update_reveal_value: operation.updateRevealValue,
+        signed_data: operation.signedData.toCompactJws()
       };
     });
 

--- a/lib/core/versions/latest/OperationProcessor.ts
+++ b/lib/core/versions/latest/OperationProcessor.ts
@@ -179,7 +179,7 @@ export default class OperationProcessor implements IOperationProcessor {
     }
 
     // Verify the actual delta hash against the expected delta hash.
-    const isMatchingDelta = Multihash.isValidHash(operation.encodedDelta, operation.signedData.deltaHash);
+    const isMatchingDelta = Multihash.isValidHash(operation.encodedDelta, operation.signedData.delta_hash);
     if (!isMatchingDelta) {
       return didState;
     }
@@ -203,8 +203,8 @@ export default class OperationProcessor implements IOperationProcessor {
     const newDidState = {
       didUniqueSuffix: operation.didUniqueSuffix,
       document,
-      recoveryKey: operation.signedData.recoveryKey,
-      nextRecoveryCommitmentHash: operation.signedData.nextRecoveryCommitmentHash,
+      recoveryKey: operation.signedData.recovery_key,
+      nextRecoveryCommitmentHash: operation.signedData.recovery_commitment,
       nextUpdateCommitmentHash: delta ? delta.updateCommitment : undefined,
       lastOperationTransactionNumber: anchoredOperationModel.transactionNumber
     };

--- a/lib/core/versions/latest/OperationProcessor.ts
+++ b/lib/core/versions/latest/OperationProcessor.ts
@@ -127,7 +127,7 @@ export default class OperationProcessor implements IOperationProcessor {
     }
 
     // Verify the delta hash against the expected delta hash.
-    const isValidDelta = Multihash.isValidHash(operation.encodedDelta, operation.signedData.payload);
+    const isValidDelta = Multihash.isValidHash(operation.encodedDelta, operation.signedData.delta_hash);
     if (!isValidDelta) {
       return didState;
     }

--- a/lib/core/versions/latest/RecoverOperation.ts
+++ b/lib/core/versions/latest/RecoverOperation.ts
@@ -12,9 +12,9 @@ import OperationType from '../../enums/OperationType';
 import SidetreeError from '../../../common/SidetreeError';
 
 interface SignedDataModel {
-  deltaHash: string;
-  recoveryKey: JwkEs256k;
-  nextRecoveryCommitmentHash: string;
+  delta_hash: string;
+  recovery_key: JwkEs256k;
+  recovery_commitment: string;
 }
 
 /**
@@ -161,12 +161,12 @@ export default class RecoverOperation implements OperationModel {
       throw new SidetreeError(ErrorCode.RecoverOperationSignedDataMissingOrUnknownProperty);
     }
 
-    Jwk.validateJwkEs256k(signedData.recoveryKey);
+    Jwk.validateJwkEs256k(signedData.recovery_key);
 
-    const deltaHash = Encoder.decodeAsBuffer(signedData.deltaHash);
+    const deltaHash = Encoder.decodeAsBuffer(signedData.delta_hash);
     Multihash.verifyHashComputedUsingLatestSupportedAlgorithm(deltaHash);
 
-    const nextRecoveryCommitmentHash = Encoder.decodeAsBuffer(signedData.nextRecoveryCommitmentHash);
+    const nextRecoveryCommitmentHash = Encoder.decodeAsBuffer(signedData.recovery_commitment);
     Multihash.verifyHashComputedUsingLatestSupportedAlgorithm(nextRecoveryCommitmentHash);
 
     return signedData;

--- a/lib/core/versions/latest/RecoverOperation.ts
+++ b/lib/core/versions/latest/RecoverOperation.ts
@@ -105,22 +105,22 @@ export default class RecoverOperation implements OperationModel {
       throw new SidetreeError(ErrorCode.RecoverOperationMissingOrUnknownProperty);
     }
 
-    if (typeof operationObject.didUniqueSuffix !== 'string') {
+    if (typeof operationObject.did_suffix !== 'string') {
       throw new SidetreeError(ErrorCode.RecoverOperationMissingOrInvalidDidUniqueSuffix);
     }
 
-    if (typeof operationObject.recoveryRevealValue !== 'string') {
+    if (typeof operationObject.recovery_reveal_value !== 'string') {
       throw new SidetreeError(ErrorCode.RecoverOperationRecoveryRevealValueMissingOrInvalidType);
     }
 
-    if ((operationObject.recoveryRevealValue as string).length > Operation.maxEncodedRevealValueLength) {
+    if ((operationObject.recovery_reveal_value as string).length > Operation.maxEncodedRevealValueLength) {
       throw new SidetreeError(ErrorCode.RecoverOperationRecoveryRevealValueTooLong);
     }
 
-    const recoveryRevealValue = operationObject.recoveryRevealValue;
+    const recoveryRevealValue = operationObject.recovery_reveal_value;
 
     const expectKidInHeader = false;
-    const signedDataJws = Jws.parseCompactJws(operationObject.signedData, expectKidInHeader);
+    const signedDataJws = Jws.parseCompactJws(operationObject.signed_data, expectKidInHeader);
     const signedData = await RecoverOperation.parseSignedDataPayload(signedDataJws.payload);
 
     // If not in anchor file mode, we need to validate `type` and `delta` properties.
@@ -143,7 +143,7 @@ export default class RecoverOperation implements OperationModel {
 
     return new RecoverOperation(
       operationBuffer,
-      operationObject.didUniqueSuffix,
+      operationObject.did_suffix,
       recoveryRevealValue,
       signedDataJws,
       signedData,

--- a/lib/core/versions/latest/UpdateOperation.ts
+++ b/lib/core/versions/latest/UpdateOperation.ts
@@ -89,22 +89,22 @@ export default class UpdateOperation implements OperationModel {
       throw new SidetreeError(ErrorCode.UpdateOperationMissingOrUnknownProperty);
     }
 
-    if (typeof operationObject.didUniqueSuffix !== 'string') {
+    if (typeof operationObject.did_suffix !== 'string') {
       throw new SidetreeError(ErrorCode.UpdateOperationMissingDidUniqueSuffix);
     }
 
-    if (typeof operationObject.updateRevealValue !== 'string') {
+    if (typeof operationObject.update_reveal_value !== 'string') {
       throw new SidetreeError(ErrorCode.UpdateOperationUpdateRevealValueMissingOrInvalidType);
     }
 
-    if ((operationObject.updateRevealValue as string).length > Operation.maxEncodedRevealValueLength) {
+    if ((operationObject.update_reveal_value as string).length > Operation.maxEncodedRevealValueLength) {
       throw new SidetreeError(ErrorCode.UpdateOperationUpdateRevealValueTooLong);
     }
 
-    const updateRevealValue = operationObject.updateRevealValue;
+    const updateRevealValue = operationObject.update_reveal_value;
 
     const expectKidInHeader = true;
-    const signedData = Jws.parseCompactJws(operationObject.signedData, expectKidInHeader);
+    const signedData = Jws.parseCompactJws(operationObject.signed_data, expectKidInHeader);
 
     // If not in map file mode, we need to validate `type` and `delta` properties.
     let encodedDelta = undefined;
@@ -118,7 +118,7 @@ export default class UpdateOperation implements OperationModel {
       delta = await Operation.parseDelta(encodedDelta);
     }
 
-    return new UpdateOperation(operationBuffer, operationObject.didUniqueSuffix,
+    return new UpdateOperation(operationBuffer, operationObject.did_suffix,
       updateRevealValue, signedData, encodedDelta, delta);
   }
 }

--- a/tests/core/AnchorFile.spec.ts
+++ b/tests/core/AnchorFile.spec.ts
@@ -138,7 +138,7 @@ describe('AnchorFile', async () => {
       delete createOperationRequest.type;
       delete createOperationRequest.delta;
 
-      const deactivateOperationRequest = await OperationGenerator.generateDeactivateOperationRequest(
+      const deactivateOperationRequest = await OperationGenerator.createDeactivateOperationRequest(
         createOperationData.createOperation.didUniqueSuffix, // Intentionally using the same DID unique suffix.
         'anyRecoveryRevealValue',
         createOperationData.recoveryPrivateKey

--- a/tests/core/DeactivateOperation.spec.ts
+++ b/tests/core/DeactivateOperation.spec.ts
@@ -11,7 +11,7 @@ describe('DeactivateOperation', async () => {
     it('should throw if operation contains unknown property', async (done) => {
       const [, recoveryPrivateKey] = await Jwk.generateEs256kKeyPair();
 
-      const deactivateOperationRequest = await OperationGenerator.generateDeactivateOperationRequest(
+      const deactivateOperationRequest = await OperationGenerator.createDeactivateOperationRequest(
         'unused-DID-unique-suffix',
         'unused-recovery-reveal-value',
         recoveryPrivateKey
@@ -24,10 +24,10 @@ describe('DeactivateOperation', async () => {
       done();
     });
 
-    it('should throw if operation type is incorrect', async (done) => {
+    it('should throw if operation type is incorrect.', async (done) => {
       const [, recoveryPrivateKey] = await Jwk.generateEs256kKeyPair();
 
-      const deactivateOperationRequest = await OperationGenerator.generateDeactivateOperationRequest(
+      const deactivateOperationRequest = await OperationGenerator.createDeactivateOperationRequest(
         'unused-DID-unique-suffix',
         'unused-recovery-reveal-value',
         recoveryPrivateKey
@@ -43,13 +43,13 @@ describe('DeactivateOperation', async () => {
     it('should throw if didUniqueSuffix is not string.', async (done) => {
       const [, recoveryPrivateKey] = await Jwk.generateEs256kKeyPair();
 
-      const deactivateOperationRequest = await OperationGenerator.generateDeactivateOperationRequest(
+      const deactivateOperationRequest = await OperationGenerator.createDeactivateOperationRequest(
         'unused-DID-unique-suffix',
         'unused-recovery-reveal-value',
         recoveryPrivateKey
       );
 
-      (deactivateOperationRequest.didUniqueSuffix as any) = 123; // Intentionally incorrect type.
+      (deactivateOperationRequest.did_suffix as any) = 123; // Intentionally incorrect type.
 
       const operationBuffer = Buffer.from(JSON.stringify(deactivateOperationRequest));
       await expectAsync(DeactivateOperation
@@ -60,13 +60,13 @@ describe('DeactivateOperation', async () => {
     it('should throw if recoveryRevealValue is not string.', async (done) => {
       const [, recoveryPrivateKey] = await Jwk.generateEs256kKeyPair();
 
-      const deactivateOperationRequest = await OperationGenerator.generateDeactivateOperationRequest(
+      const deactivateOperationRequest = await OperationGenerator.createDeactivateOperationRequest(
         'unused-DID-unique-suffix',
         'unused-recovery-reveal-value',
         recoveryPrivateKey
       );
 
-      (deactivateOperationRequest.recoveryRevealValue as any) = 123; // Intentionally incorrect type.
+      (deactivateOperationRequest.recovery_reveal_value as any) = 123; // Intentionally incorrect type.
 
       const operationBuffer = Buffer.from(JSON.stringify(deactivateOperationRequest));
       await expectAsync(DeactivateOperation.parse(operationBuffer))
@@ -77,7 +77,7 @@ describe('DeactivateOperation', async () => {
     it('should throw if recoveryRevealValue is too long.', async (done) => {
       const [, recoveryPrivateKey] = await Jwk.generateEs256kKeyPair();
 
-      const deactivateOperationRequest = await OperationGenerator.generateDeactivateOperationRequest(
+      const deactivateOperationRequest = await OperationGenerator.createDeactivateOperationRequest(
         'unused-DID-unique-suffix',
         'super-long-reveal-super-long-reveal-super-long-reveal-super-long-reveal-super-long-reveal-super-long-reveal-super-long-reveal-super-long-reveal',
         recoveryPrivateKey
@@ -118,12 +118,12 @@ describe('DeactivateOperation', async () => {
       done();
     });
 
-    it('should throw if signed `recoveryRevealValue` is mismatching.', async (done) => {
+    it('should throw if signed `recovery_reveal_value` is mismatching.', async (done) => {
       const didUniqueSuffix = 'anyUnusedDidUniqueSuffix';
       const recoveryRevealValue = 'anyUnusedRecoveryRevealValue';
       const signedData = {
-        didUniqueSuffix,
-        recoveryRevealValue
+        did_suffix: didUniqueSuffix,
+        recovery_reveal_value: recoveryRevealValue
       };
       const encodedSignedData = Encoder.encode(JSON.stringify(signedData));
       await expectAsync((DeactivateOperation as any).parseSignedDataPayload(encodedSignedData, didUniqueSuffix, 'mismatchingRecoveryRevealValue'))

--- a/tests/core/Multihash.spec.ts
+++ b/tests/core/Multihash.spec.ts
@@ -33,6 +33,12 @@ describe('Multihash', async () => {
   });
 
   describe('isValidHash()', async () => {
+    it('should return false if content is undefined', async () => {
+      const [, anyCommitment] = OperationGenerator.generateCommitRevealPair();
+      const result = Multihash.isValidHash(undefined, anyCommitment);
+      expect(result).toBeFalsy();
+    });
+
     it('should return false if encountered an unexpected error.', async () => {
       const [revealValue, commitmentHash] = OperationGenerator.generateCommitRevealPair();
 

--- a/tests/core/Operation.spec.ts
+++ b/tests/core/Operation.spec.ts
@@ -5,6 +5,19 @@ import Multihash from '../../lib/core/versions/latest/Multihash';
 import SidetreeError from '../../lib/common/SidetreeError';
 
 describe('Operation', async () => {
+  describe('parse()', async () => {
+    it('should throw if operation of unknown type is given.', async (done) => {
+      const operationOfUnknownType = {
+        type: 'unknown',
+        anyProperty: 'anyContent'
+      };
+      const operationBuffer = Buffer.from(JSON.stringify(operationOfUnknownType));
+
+      await expectAsync(Operation.parse(operationBuffer)).toBeRejectedWith(new SidetreeError(ErrorCode.OperationTypeUnknownOrMissing));
+      done();
+    });
+  });
+
   describe('parseDelta()', async () => {
     it('should throw if delta is not string', async () => {
       await expectAsync(Operation.parseDelta(123)).toBeRejectedWith(new SidetreeError(ErrorCode.DeltaMissingOrNotString));

--- a/tests/core/RecoverOperation.spec.ts
+++ b/tests/core/RecoverOperation.spec.ts
@@ -50,7 +50,7 @@ describe('RecoverOperation', async () => {
         unusedNextUpdateCommitmentHash
       );
 
-      (recoverOperationRequest.didUniqueSuffix as any) = 123; // Intentionally incorrect type.
+      (recoverOperationRequest.did_suffix as any) = 123; // Intentionally incorrect type.
 
       const operationBuffer = Buffer.from(JSON.stringify(recoverOperationRequest));
       await expectAsync(RecoverOperation.parse(operationBuffer)).toBeRejectedWith(new SidetreeError(ErrorCode.RecoverOperationMissingOrInvalidDidUniqueSuffix));
@@ -74,7 +74,7 @@ describe('RecoverOperation', async () => {
         unusedNextUpdateCommitmentHash
       );
 
-      (recoverOperationRequest.recoveryRevealValue as any) = 123; // Intentionally incorrect type.
+      (recoverOperationRequest.recovery_reveal_value as any) = 123; // Intentionally incorrect type.
 
       const operationBuffer = Buffer.from(JSON.stringify(recoverOperationRequest));
       await expectAsync(RecoverOperation.parse(operationBuffer))

--- a/tests/core/UpdateOperation.spec.ts
+++ b/tests/core/UpdateOperation.spec.ts
@@ -18,7 +18,7 @@ describe('UpdateOperation', async () => {
         signingPrivateKey
       );
 
-      (updateOperationRequest.didUniqueSuffix as any) = 123;
+      (updateOperationRequest.did_suffix as any) = 123;
 
       const operationBuffer = Buffer.from(JSON.stringify(updateOperationRequest));
       await expectAsync(UpdateOperation.parse(operationBuffer)).toBeRejectedWith(new SidetreeError(ErrorCode.UpdateOperationMissingDidUniqueSuffix));
@@ -54,7 +54,7 @@ describe('UpdateOperation', async () => {
         signingPrivateKey
       );
 
-      (updateOperationRequest.updateRevealValue as any) = 123; // Intentionally incorrect type.
+      (updateOperationRequest.update_reveal_value as any) = 123; // Intentionally incorrect type.
 
       const operationBuffer = Buffer.from(JSON.stringify(updateOperationRequest));
       await expectAsync(UpdateOperation.parse(operationBuffer))

--- a/tests/core/UpdateOperation.spec.ts
+++ b/tests/core/UpdateOperation.spec.ts
@@ -1,3 +1,4 @@
+import Encoder from '../../lib/core/versions/latest/Encoder';
 import ErrorCode from '../../lib/core/versions/latest/ErrorCode';
 import OperationGenerator from '../generators/OperationGenerator';
 import OperationType from '../../lib/core/enums/OperationType';
@@ -75,6 +76,35 @@ describe('UpdateOperation', async () => {
 
       const operationBuffer = Buffer.from(JSON.stringify(updateOperationRequest));
       await expectAsync(UpdateOperation.parse(operationBuffer)).toBeRejectedWith(new SidetreeError(ErrorCode.UpdateOperationUpdateRevealValueTooLong));
+    });
+  });
+
+  describe('parseObject()', async () => {
+    it('should throw if operation contains an additional unknown property.', async (done) => {
+      const updateOperation = {
+        did_suffix: 'unusedSuffix',
+        update_reveal_value: 'unusedReveal',
+        signed_data: 'unusedSignedData',
+        extraProperty: 'thisPropertyShouldCauseErrorToBeThrown'
+      };
+
+      const mapFileMode = true;
+      await expectAsync((UpdateOperation as any).parseObject(updateOperation, Buffer.from('anyValue'), mapFileMode))
+        .toBeRejectedWith(new SidetreeError(ErrorCode.UpdateOperationMissingOrUnknownProperty));
+      done();
+    });
+  });
+
+  describe('parseSignedDataPayload()', async () => {
+    it('should throw if signedData contains an additional unknown property.', async (done) => {
+      const signedData = {
+        delta_hash: 'anyUnusedHash',
+        extraProperty: 'An unknown extra property'
+      };
+      const encodedSignedData = Encoder.encode(JSON.stringify(signedData));
+      await expectAsync((UpdateOperation as any).parseSignedDataPayload(encodedSignedData))
+        .toBeRejectedWith(new SidetreeError(ErrorCode.UpdateOperationSignedDataHasMissingOrUnknownProperty));
+      done();
     });
   });
 });

--- a/tests/generators/OperationGenerator.ts
+++ b/tests/generators/OperationGenerator.ts
@@ -413,22 +413,22 @@ export default class OperationGenerator {
   /**
    * Generates a deactivate operation request.
    */
-  public static async generateDeactivateOperationRequest (
+  public static async createDeactivateOperationRequest (
     didUniqueSuffix: string,
     recoveryRevealValue: string,
     recoveryPrivateKey: JwkEs256k) {
 
     const signedDataPayloadObject = {
-      didUniqueSuffix,
-      recoveryRevealValue
+      did_suffix: didUniqueSuffix,
+      recovery_reveal_value: recoveryRevealValue
     };
     const signedData = await OperationGenerator.signUsingEs256k(signedDataPayloadObject, recoveryPrivateKey);
 
     const operation = {
       type: OperationType.Deactivate,
-      didUniqueSuffix,
-      recoveryRevealValue,
-      signedData
+      did_suffix: didUniqueSuffix,
+      recovery_reveal_value: recoveryRevealValue,
+      signed_data: signedData
     };
 
     return operation;
@@ -552,7 +552,7 @@ export default class OperationGenerator {
     didUniqueSuffix: string,
     recoveryRevealValueEncodedSring: string,
     privateKey: JwkEs256k): Promise<Buffer> {
-    const operation = await OperationGenerator.generateDeactivateOperationRequest(didUniqueSuffix, recoveryRevealValueEncodedSring, privateKey);
+    const operation = await OperationGenerator.createDeactivateOperationRequest(didUniqueSuffix, recoveryRevealValueEncodedSring, privateKey);
     return Buffer.from(JSON.stringify(operation));
   }
 

--- a/tests/generators/OperationGenerator.ts
+++ b/tests/generators/OperationGenerator.ts
@@ -392,9 +392,9 @@ export default class OperationGenerator {
     const deltaHash = Encoder.encode(Multihash.hash(deltaBuffer));
 
     const signedDataPayloadObject = {
-      deltaHash,
-      recoveryKey: newRecoveryPublicKey,
-      nextRecoveryCommitmentHash
+      delta_hash: deltaHash,
+      recovery_key: newRecoveryPublicKey,
+      recovery_commitment: nextRecoveryCommitmentHash
     };
     const signedData = await OperationGenerator.signUsingEs256k(signedDataPayloadObject, recoveryPrivateKey);
 

--- a/tests/generators/OperationGenerator.ts
+++ b/tests/generators/OperationGenerator.ts
@@ -325,10 +325,13 @@ export default class OperationGenerator {
       update_commitment: nextUpdateCommitmentHash
     };
     const deltaJsonString = JSON.stringify(delta);
+    const deltaHash = Encoder.encode(Multihash.hash(Buffer.from(deltaJsonString)));
     const encodedDeltaString = Encoder.encode(deltaJsonString);
 
-    const deltaHash = Multihash.hash(Buffer.from(deltaJsonString));
-    const signedData = await OperationGenerator.signUsingEs256k(deltaHash, signingPrivateKey, signingKeyId);
+    const signedDataPayloadObject = {
+      delta_hash: deltaHash
+    };
+    const signedData = await OperationGenerator.signUsingEs256k(signedDataPayloadObject, signingPrivateKey, signingKeyId);
 
     const updateOperationRequest = {
       type: OperationType.Update,

--- a/tests/generators/OperationGenerator.ts
+++ b/tests/generators/OperationGenerator.ts
@@ -332,10 +332,10 @@ export default class OperationGenerator {
 
     const updateOperationRequest = {
       type: OperationType.Update,
-      didUniqueSuffix,
-      updateRevealValue,
+      did_suffix: didUniqueSuffix,
+      update_reveal_value: updateRevealValue,
       delta: encodedDeltaString,
-      signedData
+      signed_data: signedData
     };
 
     return updateOperationRequest;

--- a/tests/generators/OperationGenerator.ts
+++ b/tests/generators/OperationGenerator.ts
@@ -401,9 +401,9 @@ export default class OperationGenerator {
     const deltaEncodedString = Encoder.encode(deltaBuffer);
     const operation = {
       type: OperationType.Recover,
-      didUniqueSuffix,
-      recoveryRevealValue,
-      signedData,
+      did_suffix: didUniqueSuffix,
+      recovery_reveal_value: recoveryRevealValue,
+      signed_data: signedData,
       delta: deltaEncodedString
     };
 


### PR DESCRIPTION
1. Updated property names for update, recover, and deactivate operation requests per spec.
1. Added a few tests to boots code coverage.