### PR TITLE
Handle the initial case where no keys are present in a Document

### DIFF
--- a/lib/core/versions/0.9.0/models/PublicKeyModel.ts
+++ b/lib/core/versions/0.9.0/models/PublicKeyModel.ts
@@ -1,4 +1,4 @@
-import PublicKeyPurpose from "../PublicKeyPurpose";
+import PublicKeyPurpose from '../PublicKeyPurpose';
 
 /**
  * Data model representing a public key in the 'publicKey' array in patches.

--- a/lib/core/versions/latest/Document.ts
+++ b/lib/core/versions/latest/Document.ts
@@ -12,14 +12,15 @@ export default class Document {
    * @param keyId The ID of the public-key.
    */
   public static getPublicKey (document: DocumentModel, keyId: string): PublicKeyModel | undefined {
-    for (let i = 0; i < document.public_keys.length; i++) {
-      const publicKey = document.public_keys[i];
+    if (Array.isArray(document.public_keys)) {
+      for (let i = 0; i < document.public_keys.length; i++) {
+        const publicKey = document.public_keys[i];
 
-      if (publicKey.id === keyId) {
-        return publicKey;
+        if (publicKey.id === keyId) {
+          return publicKey;
+        }
       }
     }
-
     return undefined;
   }
 }

--- a/lib/core/versions/latest/DocumentComposer.ts
+++ b/lib/core/versions/latest/DocumentComposer.ts
@@ -363,7 +363,7 @@ export default class DocumentComposer {
    * Adds public keys to document.
    */
   private static addPublicKeys (document: DocumentModel, patch: any): DocumentModel {
-    const publicKeyMap = new Map(document.public_keys.map(publicKey => [publicKey.id, publicKey]));
+    const publicKeyMap = new Map((document.public_keys || []).map(publicKey => [publicKey.id, publicKey]));
 
     // Loop through all given public keys and add them if they don't exist already.
     for (let publicKey of patch.public_keys) {
@@ -381,7 +381,7 @@ export default class DocumentComposer {
    * Removes public keys from document.
    */
   private static removePublicKeys (document: DocumentModel, patch: any): DocumentModel {
-    const publicKeyMap = new Map(document.public_keys.map(publicKey => [publicKey.id, publicKey]));
+    const publicKeyMap = new Map((document.public_keys || []).map(publicKey => [publicKey.id, publicKey]));
 
     // Loop through all given public key IDs and delete them from the existing public key only if it is not a recovery key.
     for (let publicKey of patch.public_keys) {

--- a/lib/core/versions/latest/models/DocumentModel.ts
+++ b/lib/core/versions/latest/models/DocumentModel.ts
@@ -6,6 +6,6 @@ import ServiceEndpointModel from './ServiceEndpointModel';
  * NOTE: This model should ONLY be used by the `DocumentComposer`.
  */
 export default interface DocumentModel {
-  public_keys: PublicKeyModel[];
+  public_keys?: PublicKeyModel[];
   service_endpoints?: ServiceEndpointModel[];
 }

--- a/lib/core/versions/latest/models/PublicKeyModel.ts
+++ b/lib/core/versions/latest/models/PublicKeyModel.ts
@@ -1,4 +1,4 @@
-import PublicKeyPurpose from "../PublicKeyPurpose";
+import PublicKeyPurpose from '../PublicKeyPurpose';
 
 /**
  * Data model representing a public key in the 'publicKey' array in patches.

--- a/tests/core/DocumentComposer.spec.ts
+++ b/tests/core/DocumentComposer.spec.ts
@@ -436,6 +436,26 @@ describe('DocumentComposer', async () => {
   });
 
   describe('applyPatches()', async () => {
+    it('should add a key even if no keys exist yet.', async () => {
+      const document: DocumentModel = {
+      };
+      const patches = [
+        {
+          action: 'add-public-keys',
+          public_keys: [
+            { id: 'aNonRepeatingId', type: 'someType' }
+          ]
+        }
+      ];
+
+      const resultantDocument = DocumentComposer.applyPatches(document, patches);
+
+      expect(resultantDocument.public_keys).toEqual([
+        { id: 'aNonRepeatingId', type: 'someType' }
+      ]);
+
+    });
+
     it('should replace old key with the same ID with new values.', async () => {
       const document: DocumentModel = {
         public_keys: [{ id: 'aRepeatingId', type: 'someType', jwk: 'any value', purpose: [PublicKeyPurpose.General] }],


### PR DESCRIPTION
I've been running into an error with a `create` operation that invokes `add-public-keys` patches: the DocumentComposer fails because it tries to treat a missing `public_keys` property as an array.

This adds an explicit interface-level indication that `public_keys` may be absent, and adds a test to ensure that `add-public-keys` works against an empty doc.