### PR TITLE
Fixed bugs - type checking

### DIFF
--- a/tests/core/DocumentComposer.spec.ts
+++ b/tests/core/DocumentComposer.spec.ts
@@ -12,7 +12,7 @@ describe('DocumentComposer', async () => {
   describe('transformToExternalDocument', () => {
     it('should output the expected resolution result given key(s) across all purpose types.', async () => {
       const [anySigningPublicKey] = await OperationGenerator.generateKeyPair('anySigningKey');  // All purposes will be included by default.
-      const [authPublicKey] = await OperationGenerator.generateKeyPair('authePbulicKey', ['auth']);
+      const [authPublicKey] = await OperationGenerator.generateKeyPair('authePbulicKey', [PublicKeyPurpose.Auth]);
       const document = {
         public_keys: [anySigningPublicKey, authPublicKey]
       };
@@ -56,7 +56,7 @@ describe('DocumentComposer', async () => {
 
     it('should return status deactivated if next recovery commit hash is undefined', async () => {
       const [anySigningPublicKey] = await OperationGenerator.generateKeyPair('anySigningKey');
-      const [authPublicKey] = await OperationGenerator.generateKeyPair('authePbulicKey', ['auth']);
+      const [authPublicKey] = await OperationGenerator.generateKeyPair('authPublicKey', [PublicKeyPurpose.Auth]);
       const document = {
         publicKeys: [anySigningPublicKey, authPublicKey]
       };

--- a/tests/generators/OperationGenerator.ts
+++ b/tests/generators/OperationGenerator.ts
@@ -60,7 +60,7 @@ export default class OperationGenerator {
    * Mainly used for testing.
    * @returns [publicKey, privateKey]
    */
-  public static async generateKeyPair (id: string, purpose?: string[]): Promise<[PublicKeyModel, JwkEs256k]> {
+  public static async generateKeyPair (id: string, purpose?: PublicKeyPurpose[]): Promise<[PublicKeyModel, JwkEs256k]> {
     const [publicKey, privateKey] = await Jwk.generateEs256kKeyPair();
     const publicKeyModel = {
       id,
@@ -102,7 +102,7 @@ export default class OperationGenerator {
   }
 
   /**
-   * Generates an create operation.
+   * Generates a create operation.
    */
   public static async generateCreateOperation () {
     const signingKeyId = 'signingKey';


### PR DESCRIPTION
Fixed the following errors: 

- Error: sidetree/tests/generators/OperationGenerator.ts(70)
 Type '{ id: string; type: string; jwk: JwkEs256k; purpose: string[]; }' is not assignable to type 'PublicKeyModel'.
  Types of property 'purpose' are incompatible.
    Type 'string[]' is not assignable to type 'PublicKeyPurpose[]'.
      Type 'string' is not assignable to type 'PublicKeyPurpose'.

- tests/core/DocumentComposer.spec.ts:15:90 - error TS2345: Argument of type '"auth"[]' is not assignable to parameter of type 'PublicKeyPurpose[]'.
  Type '"auth"' is not assignable to type 'PublicKeyPurpose'.

15       const [authPublicKey] = await OperationGenerator.generateKeyPair('authePbulicKey', ['auth']);

- tests/core/DocumentComposer.spec.ts:59:90 - error TS2345: Argument of type '"auth"[]' is not assignable to parameter of type 'PublicKeyPurpose[]'.

59       const [authPublicKey] = await OperationGenerator.generateKeyPair('authePbulicKey', ['auth']);