### PR TITLE
Update swagger spec to valid OAS3 format

### DIFF
--- a/www/swagger/api.yml
+++ b/www/swagger/api.yml
@@ -21,14 +21,15 @@ paths:
         - Sidetree
       summary: Writes an Operation to Sidetree.
       operationId: writeSidetreeOperation
-      parameters:
-        - in: body
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/SidetreeCreateOperation'
-              - $ref: '#/components/schemas/SidetreeUpdateOperation'
-              - $ref: '#/components/schemas/SidetreeRecoverOperation'
-              - $ref: '#/components/schemas/SidetreeDeactivateOperation'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/SidetreeCreateOperation'
+                - $ref: '#/components/schemas/SidetreeUpdateOperation'
+                - $ref: '#/components/schemas/SidetreeRecoverOperation'
+                - $ref: '#/components/schemas/SidetreeDeactivateOperation'
       responses:
         '200':
           description: Success
@@ -90,8 +91,8 @@ paths:
         '404':
           description: Not Found
         '500':
-          description: Server Error
-          
+          description: Server Error        
+
   /blockchain/time:
     get:
       tags:
@@ -144,52 +145,6 @@ paths:
           description: Not Found
         '500':
           description: Server Error
-    post:
-      tags:
-        - Blockchain
-      summary: Writes a Sidetree transaction to the underlying blockchain.
-      operationId: writeBlockchainTransaction
-      parameters:
-        - in: body
-          schema:
-            $ref: '#/components/schemas/BlockchainWriteRequest'
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BlockchainTransaction'
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - type: object
-                    properties:
-                      code: 
-                        type: string
-                        const: "spending_cap_per_period_reached"
-                        description: If with the given fee (derived from minimumFee) this node will exceed the spending limit as configured in the parameters.
-                  - type: object
-                    properties:
-                      code: 
-                        type: string
-                        const: "not_enough_balace_for_write"
-                        description: If the wallet configured in the parameters does not have enough balance to complete the write operation.
-        '401':
-          description: Unauthorized
-        '404':
-          description: Not Found
-        '500':
-          description: Server Error
-          type: object
-          properties:
-            code: 
-              type: string
-              const: "normalized_fee_cannot_be_computed"
-              description: Error while computing the normalized fee.
   /blockchain/transactions:
     get:
       tags:
@@ -220,11 +175,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/BlockchainTransactions'
         '400':
-          description: Bad Request
+          description: >
+            Bad Request
+              * `invalid_transaction_number_or_time_hash`
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/ErrorResponse'
                 example: {
                   "code": "invalid_transaction_number_or_time_hash"
                 }
@@ -234,6 +191,44 @@ paths:
           description: Not Found
         '500':
           description: Server Error
+    post:
+      tags:
+        - Blockchain
+      summary: Writes a Sidetree transaction to the underlying blockchain.
+      operationId: writeBlockchainTransaction
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BlockchainWriteRequest'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlockchainTransaction'
+        '400':
+          description: >
+            Bad Request
+              * `spending_cap_per_period_reached` - If with the given fee (derived from minimumFee) this node will exceed the spending limit as configured in the parameters.
+              * `not_enough_balace_for_write` - If the wallet configured in the parameters does not have enough balance to complete the write operation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+        '500':
+          description: >
+            Server Error
+              * `normalized_fee_cannot_be_computed` - Error while computing the normalized fee.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /blockchain/transactions/first-valid:
     post:
       tags:
@@ -241,41 +236,43 @@ paths:
       summary: Get first valid Sidetree transaction
       operationId: getFirstValidTransactions
       description: Given a list of Sidetree transactions, returns the first transaction in the list that is valid. Returns 404 NOT FOUND if none of the given transactions are valid. This API is primarily used by the Sidetree core library to determine a transaction that can be used as a marker in time to reprocess transactions in the event of a block reorganization (temporary fork).
-      parameters:
-        - in: body
-          required: false
-          name: transactions
-          schema:
-            type: array
-            example: [
-              {
-                "transaction_number": 19,
-                "transaction_time": 545236,
-                "transaction_time_hash": "0000000000000000002352597f8ec45c56ad19994808e982f5868c5ff6cfef2e",
-                "anchor_string": "Qm28BKV9iiM1ZNzMsi3HbDRHDPK5U2DEhKpCYhKk83UPEg",
-                "transaction_fee_paid": 5000,
-                "normalized_transaction_fee": 100,
-                "writer": "0af7eccefa3aaa37421914923b4a2034ed5a0ad0"
-              },
-              {
-                "transaction_number": 18,
-                "transaction_time": 545236,
-                "transaction_time_hash": "0000000000000000000054f9719ef6ca646e2503a9c5caac1c6ea95ffb4af587",
-                "anchor_string": "Qmb2wxUwvEpspKXU4QNxwYQLGS2gfsAuAE9LPcn5LprS1nb",
-                "transaction_fee_paid": 30,
-                "normalized_transaction_fee": 10,
-                "writer": "0af7eccefa3aaa37421782523b4a2034ed5a0ad0"
-              },
-              {
-                "transaction_number": 16,
-                "transaction_time": 545200,
-                "transaction_time_hash": "0000000000000000000f32c84291a3305ad9e5e162d8cc363420831ecd0e2800",
-                "anchor_string": "QmbBPdjWSdJoQGHbZDvPqHxWqqeKUdzBwMTMjJGeWyUkEzK",
-                "transaction_fee_paid": 50000,
-                "normalized_transaction_fee": 150,
-                "writer": "0af7eccefa3aaa87421782523b4a2034ed5a0ad0"
-              }
-            ]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/BlockchainTransaction'
+              example: [
+                {
+                  "transaction_number": 19,
+                  "transaction_time": 545236,
+                  "transaction_time_hash": "0000000000000000002352597f8ec45c56ad19994808e982f5868c5ff6cfef2e",
+                  "anchor_string": "Qm28BKV9iiM1ZNzMsi3HbDRHDPK5U2DEhKpCYhKk83UPEg",
+                  "transaction_fee_paid": 5000,
+                  "normalized_transaction_fee": 100,
+                  "writer": "0af7eccefa3aaa37421914923b4a2034ed5a0ad0"
+                },
+                {
+                  "transaction_number": 18,
+                  "transaction_time": 545236,
+                  "transaction_time_hash": "0000000000000000000054f9719ef6ca646e2503a9c5caac1c6ea95ffb4af587",
+                  "anchor_string": "Qmb2wxUwvEpspKXU4QNxwYQLGS2gfsAuAE9LPcn5LprS1nb",
+                  "transaction_fee_paid": 30,
+                  "normalized_transaction_fee": 10,
+                  "writer": "0af7eccefa3aaa37421782523b4a2034ed5a0ad0"
+                },
+                {
+                  "transaction_number": 16,
+                  "transaction_time": 545200,
+                  "transaction_time_hash": "0000000000000000000f32c84291a3305ad9e5e162d8cc363420831ecd0e2800",
+                  "anchor_string": "QmbBPdjWSdJoQGHbZDvPqHxWqqeKUdzBwMTMjJGeWyUkEzK",
+                  "transaction_fee_paid": 50000,
+                  "normalized_transaction_fee": 150,
+                  "writer": "0af7eccefa3aaa87421782523b4a2034ed5a0ad0"
+                }
+              ]
       responses:
         '200':
           description: Success
@@ -333,45 +330,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/BlockchainLock'
         '400':
-          description: Bad Request
+          description: >
+            Bad Request
+              * `blockchain_time_out_of_range` - Blockchain time given is out of computable range.
           content:
             application/json:
               schema:
-                oneOf:
-                  - type: object
-                    properties:
-                      code: 
-                        type: string
-                        const: "blockchain_time_out_of_range"
-                        description: Blockchain time given is out of computable range.
+                $ref: '#/components/schemas/ErrorResponse'
         '401':
           description: Unauthorized
         '404':
-          oneof:
-            - type: object
-              properties:
-                code: 
-                  type: string
-                  const: "value_time_lock_not_found"
-                  description:  Lock not found.
-            - type: object
-              properties:
-                code: 
-                  type: string
-                  const: "value_time_lock_in_pending_state"
-                  description:  If there is a lock but is not confirmed on the blockchain yet.
-        '500':
-          description: Server Error
+          description: >
+            Not Found
+              * `value_time_lock_not_found` - Lock not found.
+              * `value_time_lock_in_pending_state` - If there is a lock but is not confirmed on the blockchain yet.
           content:
             application/json:
               schema:
-                oneOf:
-                  - type: object
-                    properties:
-                      code: 
-                        type: string
-                        const: "normalized_fee_cannot_be_computed"
-                        description: Error while computing the normalized fee.
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: >
+            Server Error
+              * `normalized_fee_cannot_be_computed` - Error while computing the normalized fee.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /blockchain/writer-lock:
     get:
       tags:
@@ -389,26 +373,21 @@ paths:
         '401':
           description: Unauthorized
         '404':
-          oneof:
-            - type: object
-              properties:
-                code: 
-                  type: string
-                  const: "value_time_lock_not_found"
-                  description:  Lock not found.
-            - type: object
-              properties:
-                code: 
-                  type: string
-                  const: "value_time_lock_in_pending_state"
-                  description:  If there is a lock but is not confirmed on the blockchain yet.
+          description: >
+            Not Found
+              * `value_time_lock_not_found` - Lock not found.
+              * `value_time_lock_in_pending_state` - If there is a lock but is not confirmed on the blockchain yet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Server Error
   /blockchain/version:
     get:
       tags:
         - Blockchain
-      operationId: getVersion
+      operationId: getBlockchainVersion
       responses:
         '200':
           description: Success
@@ -468,29 +447,20 @@ paths:
         '200':
           description: Success
           content:
-            application/octet-stream
+            application/octet-stream:
+              schema:
+                format: binary
           
         '400':
-          description: Bad Request
-          oneof:
-            - type: object
-              properties:
-                code: 
-                  type: string
-                  const: "content_exceeds_maximum_allowed_size"
-                  description:  Content exceeds maximum allowed size
-            - type: object
-              properties:
-                code: 
-                  type: string
-                  const: "content_not_a_file"
-                  description:  Content not a file
-            - type: object
-              properties:
-                code: 
-                  type: string
-                  const: "content_hash_invalid"
-                  description:  Content hash is invalid
+          description: >
+            Bad Request
+              * `content_exceeds_maximum_allowed_size` - Content exceeds maximum allowed size
+              * `content_not_a_file` - Content not a file
+              * `content_hash_invalid` - Content hash is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '401':
           description: Unauthorized
         '404':
@@ -502,13 +472,12 @@ paths:
       tags:
         - Content Addressed Storage
       operationId: writeContent
-      parameters:
-          - in: header
-            name: Content-Type
+      requestBody:
+        content:
+          application/octet-stream:
             schema:
               type: string
-              const: application/octet-stream
-            required: true
+              format: binary
       responses:
         '200':
           description: Success
@@ -633,7 +602,7 @@ components:
           description: A number representing the normalized transaction fee used for proof-of-fee calculation.
         writer:
           type: string
-          description: A string representing the writer of the transaction. Used in the value time lock calculations.          
+          description: A string representing the writer of the transaction. Used in the value time lock calculations.
       example: {
         "transaction_number": 89,
         "transaction_time": 545236,
@@ -669,11 +638,13 @@ components:
       type: object
       properties:
         more_transactions:
-          type: bool
+          type: boolean
           description: True if there are more transactions beyond the returned batch. False otherwise.
-          example: "false"
+          example: false
         transactions:
           type: array
+          items:
+            $ref: '#/components/schemas/BlockchainTransaction'
           description: The transactions array must always end with a complete block of data, but can start in the middle of a block if since query parameter is provided.
       example: {
         "more_transactions": false,
@@ -712,7 +683,6 @@ components:
         "minimum_fee": 200000,
         "anchor_string": "QmbJGU4wNti6vNMGMosXaHbeMHGu9PkAUZtVBb2s2Vyq5d"
       }
-
     BlockchainFeeResponse:
       type: object
       properties:
@@ -747,3 +717,20 @@ components:
         "owner": "Hhdofkeio209aanoiyyoiknadfsedsed652",
         "unlock_transaction_time": 167530
       }
+    ErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          enum: 
+          - content_exceeds_maximum_allowed_size
+          - content_not_a_file
+          - content_hash_invalid
+          - value_time_lock_not_found
+          - value_time_lock_in_pending_state
+          - normalized_fee_cannot_be_computed
+          - blockchain_time_out_of_range
+          - spending_cap_per_period_reached
+          - not_enough_balace_for_write
+          - invalid_transaction_number_or_time_hash
+         


### PR DESCRIPTION
Signed-off-by: Tomislav Markovski <tmarkovski@gmail.com>

Updated swagger to be valid OAS3 spec. Consolidated error response in a single schema. Moved individual error codes to description.
This allows generators to correctly generate code. In addition, strongly typed languages generally prefer defined models in components, instead inline schema.

I tested this with autorest and NSwag, generated C# and typescript code, it looked fine.