### PR TITLE
refactor(ref-imp): Separating the freeze txn signing from the sidetree transaction signing

### DIFF
--- a/lib/bitcoin/BitcoinWallet.ts
+++ b/lib/bitcoin/BitcoinWallet.ts
@@ -39,17 +39,28 @@ export default class BitcoinWallet implements IBitcoinWallet {
     return transaction.sign(this.walletPrivateKey);
   }
 
-  public async signSpendFromFreezeTransaction (lockTransaction: Transaction, redeemScript: Script): Promise<Transaction> {
+  public async signFreezeTransaction (transaction: Transaction, _outputRedeemScript: Script): Promise<Transaction> {
+
+    // In this implementation of the wallet, we are not using the output-redeem-script parameter for anything. We'll
+    // treat the signing of this transaction same as a regular non-freeze transaction.
+    return this.signTransaction(transaction);
+  }
+
+  public async signSpendFromFreezeTransaction (
+    lockTransaction: Transaction,
+    inputRedeemScript: Script,
+    _outputRedeemScript: Script | undefined): Promise<Transaction> {
+
     // Create signature
     const signatureType = 0x1; // https://github.com/bitpay/bitcore-lib/blob/44eb5b264b9a28e376cdcf3506160a95cc499533/lib/crypto/signature.js#L308
     const inputIndexToSign = 0;
-    const signature = (Transaction as any).sighash.sign(lockTransaction, this.walletPrivateKey, signatureType, inputIndexToSign, redeemScript);
+    const signature = (Transaction as any).sighash.sign(lockTransaction, this.walletPrivateKey, signatureType, inputIndexToSign, inputRedeemScript);
 
     // Create a script and add it to the input.
     const inputScript = Script.empty()
                               .add(signature.toTxFormat())
                               .add(this.walletPublicKeyAsBuffer)
-                              .add(redeemScript.toBuffer());
+                              .add(inputRedeemScript.toBuffer());
 
     (lockTransaction.inputs[0] as any).setScript(inputScript);
 

--- a/lib/bitcoin/interfaces/IBitcoinWallet.ts
+++ b/lib/bitcoin/interfaces/IBitcoinWallet.ts
@@ -28,11 +28,23 @@ export default interface IBitcoinWallet {
   signTransaction (transaction: Transaction): Promise<Transaction>;
 
   /**
+   * Signs the specified freeeze transaction using the keys associated with this wallet. The freeze transaction is
+   * the one which freezes the funds from a previously unfrozen outputs.
+   *
+   * @param transaction The transaction to sign.
+   * @param outputRedeemScript The redeem script for the frozen output.
+   *
+   * @returns The signed transaction.
+   */
+  signFreezeTransaction (transaction: Transaction, outputRedeemScript: Script): Promise<Transaction>;
+
+  /**
    * Signs the specified transaction using the keys associated with this wallet.
    *
    * @param lockTransaction The lock transaction to sign.
-   * @param redeemScript The redeem script for the previously frozen transaction.
+   * @param outputRedeemScript The redeem script if the transaction is another freeze; undefined otherwise.
+   * @param inputRedeemScript The redeem script for the previously frozen transaction.
    * @returns The signed transaction.
    */
-  signSpendFromFreezeTransaction (lockTransaction: Transaction, redeemScript: Script): Promise<Transaction>;
+  signSpendFromFreezeTransaction (lockTransaction: Transaction, inputRedeemScript: Script, outputRedeemScript: Script | undefined): Promise<Transaction>;
 }

--- a/tests/bitcoin/BitcoinClient.spec.ts
+++ b/tests/bitcoin/BitcoinClient.spec.ts
@@ -200,7 +200,7 @@ describe('BitcoinClient', async () => {
       const createFreezeTxnSpy = spyOn(bitcoinClient as any, 'createFreezeTransaction').and.returnValue(Promise.resolve(mockCreateFreezeTxnOutput));
 
       const mockSignedTxn = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString, 19988);
-      const signSpy = spyOn(bitcoinClient['bitcoinWallet'], 'signTransaction').and.returnValue(Promise.resolve(mockSignedTxn));
+      const signSpy = spyOn(bitcoinClient['bitcoinWallet'], 'signFreezeTransaction').and.returnValue(Promise.resolve(mockSignedTxn));
 
       const mockSerializedTxn = 'mocked serialized transaction';
       const serializeSpy = spyOn(BitcoinClient as any, 'serializeSignedTransaction').and.returnValue(mockSerializedTxn);
@@ -292,7 +292,7 @@ describe('BitcoinClient', async () => {
 
       expect(createBack2WalletTxnSpy).toHaveBeenCalledWith(mockPreviousFreezeTxn, existingLockBlockInput);
       expect(createScriptSpy).toHaveBeenCalledWith(existingLockBlockInput, walletAddressFromBitcoinClient);
-      expect(signSpy).toHaveBeenCalledWith(mockFreezeTxn, mockPreviousRedeemScript);
+      expect(signSpy).toHaveBeenCalledWith(mockFreezeTxn, mockPreviousRedeemScript, undefined);
       expect(serializeSpy).toHaveBeenCalledWith(mockSignedTxn);
 
       const expectedOutput: BitcoinLockTransactionModel = {

--- a/tests/bitcoin/BitcoinClient.spec.ts
+++ b/tests/bitcoin/BitcoinClient.spec.ts
@@ -191,7 +191,7 @@ describe('BitcoinClient', async () => {
     it('should create the lock transaction.', async () => {
       const mockFreezeTxn = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString);
       spyOn(mockFreezeTxn, 'getFee').and.returnValue(122987);
-      const mockRedeemScript = 'some redeem script';
+      const mockRedeemScript = Script.empty().add(177);
 
       const mockUnspentOutput = BitcoinDataGenerator.generateUnspentCoin(bitcoinWalletImportString, 1233423426);
       spyOn(bitcoinClient as any, 'getUnspentOutputs').and.returnValue(Promise.resolve([mockUnspentOutput]));
@@ -211,13 +211,13 @@ describe('BitcoinClient', async () => {
       const actual = await bitcoinClient.createLockTransaction(lockAmountInput, lockUntilBlockInput);
 
       expect(createFreezeTxnSpy).toHaveBeenCalledWith([mockUnspentOutput], lockUntilBlockInput, lockAmountInput);
-      expect(signSpy).toHaveBeenCalledWith(mockFreezeTxn);
+      expect(signSpy).toHaveBeenCalledWith(mockFreezeTxn, mockRedeemScript);
       expect(serializeSpy).toHaveBeenCalledWith(mockSignedTxn);
 
       const expectedOutput: BitcoinLockTransactionModel = {
         transactionId: mockSignedTxn.id,
         transactionFee: mockFreezeTxn.getFee(),
-        redeemScriptAsHex: mockRedeemScript,
+        redeemScriptAsHex: mockRedeemScript.toHex(),
         serializedTransactionObject: mockSerializedTxn
       };
       expect(actual).toEqual(expectedOutput);
@@ -231,14 +231,14 @@ describe('BitcoinClient', async () => {
       spyOn(mockFreezeTxn, 'getFee').and.returnValue(122987);
 
       const mockPreviousFreezeTxn = generateBitcoreTransactionWrapper(bitcoinWalletImportString);
-      const mockRedeemScript = 'some redeem script';
+      const mockRedeemScript = Script.empty().add(177);
 
       const mockCreateFreezeTxnOutput = [mockFreezeTxn, mockRedeemScript];
       const createFreezeTxnSpy = spyOn(bitcoinClient as any, 'createSpendToFreezeTransaction').and.returnValue(Promise.resolve(mockCreateFreezeTxnOutput));
 
       spyOn(bitcoinClient as any, 'getRawTransactionRpc').and.returnValue(Promise.resolve(mockPreviousFreezeTxn));
 
-      const mockPreviousRedeemScript = 'previous redeem script';
+      const mockPreviousRedeemScript = Script.empty().add(179);
       const createScriptSpy = spyOn(BitcoinClient as any, 'createFreezeScript').and.returnValue(mockPreviousRedeemScript);
 
       const mockSignedTxn = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString, 19988);
@@ -254,13 +254,13 @@ describe('BitcoinClient', async () => {
 
       expect(createFreezeTxnSpy).toHaveBeenCalledWith(mockPreviousFreezeTxn, existingLockBlockInput, lockUntilBlockInput);
       expect(createScriptSpy).toHaveBeenCalledWith(existingLockBlockInput, walletAddressFromBitcoinClient);
-      expect(signSpy).toHaveBeenCalledWith(mockFreezeTxn, mockPreviousRedeemScript);
+      expect(signSpy).toHaveBeenCalledWith(mockFreezeTxn, mockPreviousRedeemScript, mockRedeemScript);
       expect(serializeSpy).toHaveBeenCalledWith(mockSignedTxn);
 
       const expectedOutput: BitcoinLockTransactionModel = {
         transactionId: mockSignedTxn.id,
         transactionFee: mockFreezeTxn.getFee(),
-        redeemScriptAsHex: mockRedeemScript,
+        redeemScriptAsHex: mockRedeemScript.toHex(),
         serializedTransactionObject: mockSerializedTxn
       };
       expect(actual).toEqual(expectedOutput);
@@ -757,7 +757,7 @@ describe('BitcoinClient', async () => {
 
       const [actualTxn, redeemScript] = await bitcoinClient['createFreezeTransaction']([mockUnspentOutput], mockFreezeUntilBlock, mockFreezeAmount);
 
-      expect(redeemScript).toEqual(mockRedeemScript.toHex());
+      expect(redeemScript).toEqual(mockRedeemScript);
       expect(actualTxn.getFee()).toEqual(mockTxnFee);
 
       // There should be 2 outputs
@@ -794,7 +794,7 @@ describe('BitcoinClient', async () => {
       // tslint:disable-next-line: max-line-length
       const [actualTxn, redeemScript] = await bitcoinClient['createSpendToFreezeTransaction'](mockFreezeTxn1, mockFreezeUntilPreviousBlock, mockFreezeUntilBlock);
       expect(actualTxn).toEqual(mockFreezeTxn2);
-      expect(redeemScript).toEqual(mockRedeemScript.toHex());
+      expect(redeemScript).toEqual(mockRedeemScript);
       expect(createScriptSpy).toHaveBeenCalledWith(mockFreezeUntilBlock, walletAddressFromBitcoinClient);
 
       const expectedPayToScriptAddress = new Address(mockRedeemScriptHashOutput);


### PR DESCRIPTION
See issue #838 for motivations behind this change.