### PR TITLE
Handle estimatesmartfee errors

### DIFF
--- a/lib/bitcoin/BitcoinClient.ts
+++ b/lib/bitcoin/BitcoinClient.ts
@@ -419,8 +419,8 @@ export default class BitcoinClient {
     return BitcoinClient.convertBtcToSatoshis(feerateInBtc);
   }
 
-  /** Get the current estimated fee from RPC or return the stored estimate */
-  private async getEstimatedFeeInSatoshisPerKB (): Promise<number> {
+  /** Get the current estimated fee from RPC and update stored estimate */
+  private async updateEstimatedFeeInSatoshisPerKB (): Promise<number> {
     let estimatedFeeSatoshiPerKB;
     try {
       estimatedFeeSatoshiPerKB = await this.getCurrentEstimatedFeeInSatoshisPerKB();
@@ -546,7 +546,7 @@ export default class BitcoinClient {
    */
   private async calculateTransactionFee (transaction: Transaction): Promise<number> {
     // Get estimated fee from RPC
-    const estimatedFeePerKB = await this.getEstimatedFeeInSatoshisPerKB();
+    const estimatedFeePerKB = await this.updateEstimatedFeeInSatoshisPerKB();
 
     // Estimate the size of the transaction
     const estimatedSizeInBytes = (transaction.inputs.length * 150) + (transaction.outputs.length * 50);

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -131,7 +131,8 @@ export default class BitcoinProcessor {
         config.bitcoinWalletOrImportString,
         config.requestTimeoutInMilliseconds || 300,
         config.requestMaxRetries || 3,
-        config.sidetreeTransactionFeeMarkupPercentage || 0);
+        config.sidetreeTransactionFeeMarkupPercentage || 0,
+        config.defaultTransactionFeeInSatoshisPerKB);
 
     this.sidetreeTransactionParser = new SidetreeTransactionParser(this.bitcoinClient, this.sidetreePrefix);
 

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -493,7 +493,6 @@ export default class BitcoinProcessor {
 
     if (!feeWithinSpendingLimits) {
       throw new RequestError(ResponseStatus.BadRequest, SharedErrorCode.SpendingCapPerPeriodReached);
-
     }
 
     // Write a warning if the balance is running low

--- a/lib/bitcoin/IBitcoinConfig.ts
+++ b/lib/bitcoin/IBitcoinConfig.ts
@@ -11,6 +11,7 @@ export default interface IBitcoinConfig {
   bitcoinRpcUsername: string | undefined;
   bitcoinRpcPassword: string | undefined;
   bitcoinWalletOrImportString: IBitcoinWallet | string;
+  defaultTransactionFeeInSatoshisPerKB: number | undefined;
   lowBalanceNoticeInDays: number | undefined;
   sidetreeTransactionPrefix: string;
   genesisBlockNumber: number;

--- a/lib/core/versions/latest/DocumentComposer.ts
+++ b/lib/core/versions/latest/DocumentComposer.ts
@@ -310,7 +310,7 @@ export default class DocumentComposer {
         } catch {
           throw new SidetreeError(ErrorCode.DocumentComposerPatchServiceEndpointServiceEndpointNotValidUrl);
         }
-      } else if (typeof endpoint === 'object'){
+      } else if (typeof endpoint === 'object') {
         // Allow `object` type only if it is not an array.
         if (Array.isArray(endpoint)) {
           throw new SidetreeError(ErrorCode.DocumentComposerPatchServiceEndpointValueCannotBeAnArray);

--- a/tests/bitcoin/BitcoinClient.spec.ts
+++ b/tests/bitcoin/BitcoinClient.spec.ts
@@ -79,6 +79,12 @@ describe('BitcoinClient', async () => {
       const actual = new BitcoinClient('uri:mock', 'u', 'p', bitcoinWalletImportString, 10, 10, 10);
       expect(actual['bitcoinWallet']).toEqual(expectedWallet);
     });
+
+    it('should use the estimated fee set by the estimatedFeeSatoshiPerKB parameter', () => {
+      const expectedEstimatedFee = 42;
+      const actual = new BitcoinClient('uri:mock', 'u', 'p', ctorWallet, 10, 10, 10, expectedEstimatedFee);
+      expect(actual['estimatedFeeSatoshiPerKB']).toEqual(expectedEstimatedFee);
+    });
   });
 
   describe('createSidetreeTransaction', () => {
@@ -505,13 +511,13 @@ describe('BitcoinClient', async () => {
     });
   });
 
-  describe('getEstimatedFeeInSatoshisPerKB', () => {
+  describe('updateEstimatedFeeInSatoshisPerKB', () => {
     it('should always call the correct rpc and return the updated fee', async () => {
       const mockFeeInBitcoins = 156;
       const expectedFeeInSatoshis = mockFeeInBitcoins * 100000000;
       const spy = spyOn(bitcoinClient as any, 'getCurrentEstimatedFeeInSatoshisPerKB').and.returnValue(expectedFeeInSatoshis);
 
-      const actual = await bitcoinClient['getEstimatedFeeInSatoshisPerKB']();
+      const actual = await bitcoinClient['updateEstimatedFeeInSatoshisPerKB']();
       expect(actual).toEqual(expectedFeeInSatoshis);
       expect(bitcoinClient['estimatedFeeSatoshiPerKB']).toEqual(expectedFeeInSatoshis);
       expect(spy).toHaveBeenCalled();
@@ -525,7 +531,7 @@ describe('BitcoinClient', async () => {
       const expectedFeeInSatoshis = mockFeeInBitcoins * 100000000;
       bitcoinClient['estimatedFeeSatoshiPerKB'] = expectedFeeInSatoshis;
 
-      const actual = await bitcoinClient['getEstimatedFeeInSatoshisPerKB']();
+      const actual = await bitcoinClient['updateEstimatedFeeInSatoshisPerKB']();
       expect(actual).toEqual(expectedFeeInSatoshis);
       expect(bitcoinClient['estimatedFeeSatoshiPerKB']).toEqual(expectedFeeInSatoshis);
       expect(spy).toHaveBeenCalled();
@@ -536,7 +542,7 @@ describe('BitcoinClient', async () => {
       spy.and.throwError('test');
 
       try {
-        await bitcoinClient['getEstimatedFeeInSatoshisPerKB']();
+        await bitcoinClient['updateEstimatedFeeInSatoshisPerKB']();
         fail('should have thrown');
       } catch {
         expect(spy).toHaveBeenCalled();

--- a/tests/bitcoin/BitcoinClient.spec.ts
+++ b/tests/bitcoin/BitcoinClient.spec.ts
@@ -468,14 +468,14 @@ describe('BitcoinClient', async () => {
     });
   });
 
-  describe('getCurrentEstimatedFeeInSatoshisPerKb', () => {
+  describe('getCurrentEstimatedFeeInSatoshisPerKB', () => {
     it('should call the correct rpc and return the fee', async () => {
       const mockFeeInBitcoins = 155;
       const spy = mockRpcCall('estimatesmartfee', [1], { feerate: mockFeeInBitcoins });
 
       const expectedFeeInSatoshis = mockFeeInBitcoins * 100000000;
 
-      const actual = await bitcoinClient['getCurrentEstimatedFeeInSatoshisPerKb']();
+      const actual = await bitcoinClient['getCurrentEstimatedFeeInSatoshisPerKB']();
       expect(actual).toEqual(expectedFeeInSatoshis);
       expect(spy).toHaveBeenCalled();
     });
@@ -484,7 +484,7 @@ describe('BitcoinClient', async () => {
       const spy = mockRpcCall('estimatesmartfee', [1], { });
 
       try {
-        await bitcoinClient['getCurrentEstimatedFeeInSatoshisPerKb']();
+        await bitcoinClient['getCurrentEstimatedFeeInSatoshisPerKB']();
         fail('should have thrown');
       } catch (error) {
         expect(spy).toHaveBeenCalled();
@@ -496,12 +496,53 @@ describe('BitcoinClient', async () => {
       const spy = mockRpcCall('estimatesmartfee', [1], { feerate: 1, errors: ['some error'] });
 
       try {
-        await bitcoinClient['getCurrentEstimatedFeeInSatoshisPerKb']();
+        await bitcoinClient['getCurrentEstimatedFeeInSatoshisPerKB']();
         fail('should have thrown');
       } catch (error) {
         expect(spy).toHaveBeenCalled();
       }
       done();
+    });
+  });
+
+  describe('getEstimatedFeeInSatoshisPerKB', () => {
+    it('should always call the correct rpc and return the updated fee', async () => {
+      const mockFeeInBitcoins = 156;
+      const expectedFeeInSatoshis = mockFeeInBitcoins * 100000000;
+      const spy = spyOn(bitcoinClient as any, 'getCurrentEstimatedFeeInSatoshisPerKB').and.returnValue(expectedFeeInSatoshis);
+
+      const actual = await bitcoinClient['getEstimatedFeeInSatoshisPerKB']();
+      expect(actual).toEqual(expectedFeeInSatoshis);
+      expect(bitcoinClient['estimatedFeeSatoshiPerKB']).toEqual(expectedFeeInSatoshis);
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should always call the correct rpc and return the stored fee on error', async () => {
+      const mockFeeInBitcoins = 157;
+      const spy = spyOn(bitcoinClient as any, 'getCurrentEstimatedFeeInSatoshisPerKB');
+      spy.and.throwError('test');
+
+      const expectedFeeInSatoshis = mockFeeInBitcoins * 100000000;
+      bitcoinClient['estimatedFeeSatoshiPerKB'] = expectedFeeInSatoshis;
+
+      const actual = await bitcoinClient['getEstimatedFeeInSatoshisPerKB']();
+      expect(actual).toEqual(expectedFeeInSatoshis);
+      expect(bitcoinClient['estimatedFeeSatoshiPerKB']).toEqual(expectedFeeInSatoshis);
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should rethrow RPC error when no fee was stored', async (done) => {
+      const spy = spyOn(bitcoinClient as any, 'getCurrentEstimatedFeeInSatoshisPerKB');
+      spy.and.throwError('test');
+
+      try {
+        await bitcoinClient['getEstimatedFeeInSatoshisPerKB']();
+        fail('should have thrown');
+      } catch {
+        expect(spy).toHaveBeenCalled();
+      } finally {
+        done();
+      }
     });
   });
 
@@ -729,7 +770,7 @@ describe('BitcoinClient', async () => {
   describe('calculateTransactionFee', () => {
     it('should calculate the fee correctly', async () => {
       const estimatedFee = 1528;
-      spyOn(bitcoinClient as any, 'getCurrentEstimatedFeeInSatoshisPerKb').and.returnValue(estimatedFee);
+      spyOn(bitcoinClient as any, 'getCurrentEstimatedFeeInSatoshisPerKB').and.returnValue(estimatedFee);
 
       const mockTransaction = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString, 10000);
 
@@ -738,6 +779,38 @@ describe('BitcoinClient', async () => {
       const actualFee = await bitcoinClient['calculateTransactionFee'](mockTransaction);
 
       expect(expectedFee).toEqual(actualFee);
+    });
+
+    it('should throw if no stored estimate and the fee estimate throws', async (done) => {
+      const spy = spyOn(bitcoinClient as any, 'getCurrentEstimatedFeeInSatoshisPerKB');
+      spy.and.throwError('test');
+
+      const mockTransaction = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString, 10000);
+
+      try {
+        await bitcoinClient['calculateTransactionFee'](mockTransaction);
+        fail('should have thrown');
+      } catch {
+        expect(spy).toHaveBeenCalled();
+      } finally {
+        done();
+      }
+    });
+
+    it('should use stored estimate, if estimate fails', async () => {
+      const estimatedFee = 1529;
+      bitcoinClient['estimatedFeeSatoshiPerKB'] = estimatedFee;
+      const spy = spyOn(bitcoinClient as any, 'getCurrentEstimatedFeeInSatoshisPerKB');
+      spy.and.throwError('test');
+
+      const mockTransaction = BitcoinDataGenerator.generateBitcoinTransaction(bitcoinWalletImportString, 10000);
+
+      const expectedFee = 108;
+
+      const actualFee = await bitcoinClient['calculateTransactionFee'](mockTransaction);
+
+      expect(expectedFee).toEqual(actualFee);
+      expect(spy).toHaveBeenCalled();
     });
   });
 

--- a/tests/bitcoin/BitcoinProcessor.spec.ts
+++ b/tests/bitcoin/BitcoinProcessor.spec.ts
@@ -49,14 +49,15 @@ describe('BitcoinProcessor', () => {
     bitcoinRpcPassword: '123456789',
     bitcoinWalletOrImportString: BitcoinClient.generatePrivateKey('testnet'),
     databaseName: 'bitcoin-test',
-    requestTimeoutInMilliseconds: 300,
+    defaultTransactionFeeInSatoshisPerKB: undefined,
     genesisBlockNumber: 1480000,
     lowBalanceNoticeInDays: 28,
-    requestMaxRetries: 3,
     mongoDbConnectionString: 'mongodb://localhost:27017',
+    requestMaxRetries: 3,
+    requestTimeoutInMilliseconds: 300,
     sidetreeTransactionPrefix: 'sidetree:',
-    transactionPollPeriodInSeconds: 60,
     sidetreeTransactionFeeMarkupPercentage: 0,
+    transactionPollPeriodInSeconds: 60,
     valueTimeLockPollPeriodInSeconds: 60,
     valueTimeLockAmountInBitcoins: 1,
     valueTimeLockTransactionFeesAmountInBitcoins: undefined
@@ -144,6 +145,7 @@ describe('BitcoinProcessor', () => {
         bitcoinRpcPassword: 'password123',
         bitcoinWalletOrImportString: BitcoinClient.generatePrivateKey('testnet'),
         databaseName: randomString(),
+        defaultTransactionFeeInSatoshisPerKB: 42,
         genesisBlockNumber: randomNumber(),
         mongoDbConnectionString: randomString(),
         sidetreeTransactionPrefix: randomString(4),
@@ -165,6 +167,7 @@ describe('BitcoinProcessor', () => {
       expect(bitcoinProcessor['transactionStore'].databaseName).toEqual(config.databaseName);
       expect(bitcoinProcessor['transactionStore']['serverUrl']).toEqual(config.mongoDbConnectionString);
       expect(bitcoinProcessor['bitcoinClient']['sidetreeTransactionFeeMarkupPercentage']).toEqual(0);
+      expect(bitcoinProcessor['bitcoinClient']['estimatedFeeSatoshiPerKB']).toEqual(42);
     });
   });
 

--- a/tests/core/Did.spec.ts
+++ b/tests/core/Did.spec.ts
@@ -34,7 +34,9 @@ describe('DID', async () => {
       const largeDelta = { data: largeData };
       const testInitialState = Encoder.encode(JsonCanonicalizer.canonicalizeAsBuffer({ suffix_data: 'some data', delta: largeDelta }));
 
-      JasmineSidetreeErrorValidator.expectSidetreeErrorToBeThrown(() => { Did['constructCreateOperationFromEncodedJcs'](testInitialState); }, ErrorCode.DeltaExceedsMaximumSize);
+      JasmineSidetreeErrorValidator.expectSidetreeErrorToBeThrown(() => {
+        Did['constructCreateOperationFromEncodedJcs'](testInitialState);
+      }, ErrorCode.DeltaExceedsMaximumSize);
     });
   });
 


### PR DESCRIPTION
This PR adds a new config setting `estimatedFeeInBitcoinsPerKB: number | undefined` to be used when the `estimatesmartfee` RPC call fails. There are plenty of occasions when that RPC call fails, most prominently when using bitcoind in `-regtest` or even on testnet where there's less traffic.

Smaller changes in this PR include renames of private APIs (`Kb` to `KB` to signify kilobyte), typos, and existing lint errors.