### PR TITLE
Add concept of operation anchor timing and validity

### DIFF
--- a/docs/spec/json-web-signatures.md
+++ b/docs/spec/json-web-signatures.md
@@ -44,9 +44,29 @@ A [Recover Operation](https://identity.foundation/sidetree/spec/#recover) MUST b
 A [Deactivate Operation](https://identity.foundation/sidetree/spec/#deactivate) MUST by signed by the currently valid [Recovery Key Pair](#recovery-key-pair).
 
 ::: warning
-  Signatures on operations may be valid, but operations may be deemed invalid for other reasons (e.g. malformed delta payload).
+  Signatures on operations may be valid, but operations may be deemed invalid for other reasons (e.g. malformed delta payload or being stale).
 :::
 
 ::: warning
   It is not recommended to reuse verificationMethods for multiple verification relationships.
 :::
+
+### Operation Anchoring Time Ranges
+
+A Sidetree-based DID Method ****MAY**** define the `anchorFrom` and/or `anchorUntil` properties as part of the operation’s data object payload.
+If `anchorFrom` is defined by the implementor, a DID owner ****MAY**** include the earliest allowed anchoring time for their operation in the `anchorFrom` property of the operation’s data object payload.
+The `anchorFrom` property is conceptually similar to the [RFC7519](https://tools.ietf.org/html/rfc7519) `nbf` and `iat` claims.
+If `anchorUntil` is defined by the implementor, a DID owner ****MAY**** include the latest allowed anchoring time for their operation in the `anchorUntil` property of the operation’s data object payload.
+The `anchorUntil` property is conceptually similar to the [RFC7519](https://tools.ietf.org/html/rfc7519) `exp` claim.
+These properties contain numeric values; but note that anchoring systems may have differing mechanisms of time (as defined by the method).
+
+A Sidetree-based DID Method ****MAY**** require validation for rejecting stale operations.
+An operation is considered stale relative to the timing information provided by the underlying anchoring system.
+When an operation is stale according to the DID method’s parameters, the operation is deemed as invalid.
+During processing, if the DID method validates stale operations, the DID owner's operation time range is compared to the anchoring system’s timing information.
+Operations that are anchored prior to `anchorFrom` are deemed invalid.
+Operations that are anchored after `anchorUntil` are deemed invalid.
+
+A Sidetree-based DID Method ****MAY**** constrain the range between `anchorFrom` and `anchorUntil` using a delta defined by the implementation.
+The implementor ****MAY**** also implicitly define the `anchorUntil` using the `anchorFrom` plus a delta defined by the implementation.
+The delta ****MAY**** be defined as the `MAX_OPERATION_TIME_DELTA` protocol parameter.


### PR DESCRIPTION
This PR introduces the concept of a stale operation.

A Sidetree-based DID Method may reject stale operations. An operation is considered stale relative to the timing information provided by the underlying anchoring system. When an operation is stale according to the DID method’s parameters, the operation is deemed as invalid.