### PR TITLE
fix(ref-imp): fixed release github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   push-master:
-    # Only run on any commit that features the release commit message syntax in the commit message
-    if: "contains(github.event.head_commit.message, 'chore(ref-imp): publish release')"
+    # Only run on any commit that features the official release commit message syntax in the commit message.
+    if: "contains(github.event.head_commit.message, 'chore(ref-imp): official release')"
     name: Build, test and publish stable release
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/unstable-release.yml
+++ b/.github/workflows/unstable-release.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   push-master:
-    # Don't run on any commit that features [skip ci] in the commit message
-    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    # Only run if the push is not attempting to publish a release.
+    if: "! contains(github.event.head_commit.message, 'chore(ref-imp): official release')"
     name: Build, test and publish unstable release
     runs-on: ubuntu-latest
     strategy:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -27,8 +27,7 @@ To create a stable release follow the following steps:
 1. Run `npm run version:release`, with an appropriate option such as [ `major` | `minor` | `patch` ].
 1. Observe and note down the correctly incremented version number X.Y.Z change to the `package.json` and changes to `CHANGELOG.md`
 1. Push the release branch and open a pull request for the release.
-1. Once approvals have been sought, merge the pull request preserving the last commit message "`chore(ref-imp): publish release [skip ci]`" using **rebase**. This is how release action to publish an NPM package is triggered.
->NOTE: in theory squash merge should trigger release action also but for some reason it does not.
+1. Once approvals have been sought, merge the pull request preserving the **last** commit message "`chore(ref-imp): official release`". This is how release action to publish an NPM package is triggered.
 1. Observe the triggering of the `/.github/workflows/release.yml` github workflow
 1. Remove the tag created in the release branch: `git tag -d vX.Y.Z`
 1. Remove the local release branch:

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "util:generate-error-codes": "node dist/tests/generators/ErrorCodeGenerator.js",
     "publish:unstable": "./scripts/publish-unstable.sh",
     "publish:release": "./scripts/publish.sh",
-    "version:release": "npm version --message \"chore(ref-imp): publish release [skip ci]\"",
+    "version:release": "npm version --message \"chore(ref-imp): official release\"",
     "lint": "eslint --ext ts lib/ tests/",
     "lint:fix": "eslint --ext ts lib/ tests/ --fix",
     "spec": "node -e \"require('spec-up')({ nowatch: true })\"",


### PR DESCRIPTION
Because of https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/, we can no longer use `skip ci` string as the conditional check in our gibhub actions.