### PR TITLE
fix(ref-imp): refactored getWriterValueTimeLock() to handle error better

### DIFF
--- a/lib/core/Blockchain.ts
+++ b/lib/core/Blockchain.ts
@@ -210,19 +210,17 @@ export default class Blockchain implements IBlockchain {
   }
 
   public async getWriterValueTimeLock (): Promise<ValueTimeLockModel | undefined> {
-
     const response = await this.fetch(this.writerLockUri);
-    const responseBodyString = await ReadableStream.readAll(response.body);
-    const responseBody = await JsonAsync.parse(responseBodyString);
-
     if (response.status === HttpStatus.NOT_FOUND) {
       return undefined;
     }
 
+    const responseBodyString = await ReadableStream.readAll(response.body);
     if (response.status !== HttpStatus.OK) {
-      throw new SidetreeError(CoreErrorCode.BlockchainGetWriterLockResponseNotOk, `Response: ${responseBodyString}`);
+      throw new SidetreeError(CoreErrorCode.BlockchainGetWriterLockResponseNotOk, `Status: ${response.status}. Response: ${responseBodyString}.`);
     }
 
+    const responseBody = await JsonAsync.parse(responseBodyString);
     return responseBody;
   }
 }

--- a/tests/core/Blockchain.spec.ts
+++ b/tests/core/Blockchain.spec.ts
@@ -478,7 +478,7 @@ describe('Blockchain', async () => {
       done();
     });
 
-    it('should throw generic error if that is returned by the network call.', async (done) => {
+    it('should throw generic error if HTTP 200 is not returned by the network call.', async (done) => {
       const blockchainClient = new Blockchain('unused');
 
       const mockFetchResponse = {

--- a/tests/core/MongoDbOperationQueue.spec.ts
+++ b/tests/core/MongoDbOperationQueue.spec.ts
@@ -1,6 +1,7 @@
 import Config from '../../lib/core/models/Config';
 import ErrorCode from '../../lib/core/versions/latest/ErrorCode';
 import IOperationQueue from '../../lib/core/versions/latest/interfaces/IOperationQueue';
+import { MongoClient } from 'mongodb';
 import MongoDb from '../common/MongoDb';
 import MongoDbOperationQueue from '../../lib/core/versions/latest/MongoDbOperationQueue';
 import SidetreeError from '../../lib/common/SidetreeError';
@@ -40,6 +41,11 @@ describe('MongoDbOperationQueue', async () => {
   beforeAll(async () => {
     mongoServiceAvailable = await MongoDb.isServerAvailable(config.mongoDbConnectionString);
     if (mongoServiceAvailable) {
+      // Deleting collection before running the tests.
+      const client = await MongoClient.connect(config.mongoDbConnectionString);
+      const db = client.db(databaseName);
+      await db.dropCollection(MongoDbOperationQueue.collectionName);
+
       operationQueue = await createOperationQueue(config.mongoDbConnectionString, databaseName);
     }
   });
@@ -70,7 +76,7 @@ describe('MongoDbOperationQueue', async () => {
     }
   });
 
-  it('should deqeueue with correct count.', async () => {
+  it('should dequeue with correct count.', async () => {
     const operationCount = 3;
     const queuedOperations = await generateAndQueueOperations(operationQueue, operationCount);
 


### PR DESCRIPTION
Existing code parses too early, preventing other error handling code to take place.