### PR TITLE
Add id for max operation count parameter

### DIFF
--- a/www/spec/v1.0.0/index.html
+++ b/www/spec/v1.0.0/index.html
@@ -326,7 +326,7 @@ customElements.define("slide-panels",class extends HTMLElement{static get observ
 <td style="text-align:left">1,000 bytes</td>
 </tr>
 <tr>
-<td><code>MAX_OPERATION_COUNT</code></td>
+<td id="max-operation-count"><code>MAX_OPERATION_COUNT</code></td>
 <td>Maximum number of operations per batch.</td>
 <td style="text-align:left">10,000 ops</td>
 </tr>


### PR DESCRIPTION
The other protocol parameters have ids, that enable anchor links, e.g.:
https://identity.foundation/sidetree/spec/v1.0.0/#max-operation-hash-length