### PR TITLE
fix(ref-imp): fixed an integer precision bug in how transaction number is constructed

### DIFF
--- a/lib/bitcoin/BitcoinClient.ts
+++ b/lib/bitcoin/BitcoinClient.ts
@@ -928,7 +928,7 @@ export default class BitcoinClient {
       } else {
         networkError = new SidetreeError(
           ErrorCode.BitcoinClientFetchHttpCodeWithNetworkIssue,
-          `Network issue ith HTTP response: [${response.status}]: ${bodyBuffer}`
+          `Network issue with HTTP response: [${response.status}]: ${bodyBuffer}`
         );
 
         // Retry-able if one of these HTTP codes.

--- a/lib/bitcoin/BitcoinClient.ts
+++ b/lib/bitcoin/BitcoinClient.ts
@@ -928,7 +928,7 @@ export default class BitcoinClient {
       } else {
         networkError = new SidetreeError(
           ErrorCode.BitcoinClientFetchHttpCodeWithNetworkIssue,
-          `Unexpected HTTP response: [${response.status}]: ${bodyBuffer}`
+          `Network issue ith HTTP response: [${response.status}]: ${bodyBuffer}`
         );
 
         // Retry-able if one of these HTTP codes.
@@ -940,7 +940,10 @@ export default class BitcoinClient {
         }
 
         // All other error code, not connectivity related issue, fail straight away.
-        throw networkError;
+        throw new SidetreeError(
+          ErrorCode.BitcoinClientFetchUnexpectedError,
+          `Unexpected fetch HTTP response: [${response.status}]: ${bodyBuffer}`
+        );
       }
 
       // Else we can retry

--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -206,7 +206,7 @@ export default class BitcoinProcessor {
   }
 
   private async upgradeDatabaseIfNeeded () {
-    const expectedDbVersion = '1.0.0';
+    const expectedDbVersion = '1.1.0';
     const savedServiceState = await this.serviceStateStore.get();
     const actualDbVersion = savedServiceState.databaseVersion;
 
@@ -228,6 +228,8 @@ export default class BitcoinProcessor {
 
     // Current upgrade action is simply clearing/deleting existing DB such that initial sync can occur from genesis block.
     const timer = timeSpan();
+    await this.blockMetadataStore.clearCollection();
+    await this.transactionStore.clearCollection();
 
     await this.serviceStateStore.put({ databaseVersion: expectedDbVersion });
 

--- a/lib/bitcoin/ErrorCode.ts
+++ b/lib/bitcoin/ErrorCode.ts
@@ -1,5 +1,6 @@
 export default {
   BitcoinBlockMetadataNotFound: 'bitcoin_block_metadata_not_found',
+  BitcoinClientFetchUnexpectedError: 'bitcoin_client_fetch_unexpected_error',
   BitcoinClientFetchHttpCodeWithNetworkIssue: 'bitcoin_client_fetch_http_code_with_network_issue',
   BitcoinFileReaderBlockCannotReadDirectory: 'bitcoin_file_reader_block_cannot_read_directory',
   BitcoinFileReaderBlockCannotReadFile: 'bitcoin_file_reader_block_cannot_read_file',
@@ -8,6 +9,7 @@ export default {
   BitcoinProcessInvalidPreviousBlockHash: 'bitcoin_processor_invalid_previous_block_hash',
   BitcoinRawDataParserInvalidBlockData: 'bitcoin_raw_data_parser_invalid_block_data',
   BitcoinRawDataParserInvalidMagicBytes: 'bitcoin_raw_data_parser_invalid_magic_bytes',
+  DatabaseDowngradeNotAllowed: 'database_downgrade_not_allowed',
   LockIdentifierIncorrectFormat: 'lock_identifier_incorrect_format',
   LockMonitorCurrentValueTimeLockInPendingState: 'lock_monitor_current_value_time_lock_in_pending_state',
   LockMonitorDesiredLockAmountIsNotWholeNumber: 'lock_monitor_desired_lock_amount_is_not_whole_number',
@@ -20,7 +22,8 @@ export default {
   LockResolverTransactionIsNotPayingToScript: 'lock_resolver_transaction_is_not_paying_to_script',
   LockResolverTransactionNotConfirmed: 'lock_resolver_transaction_not_confirmed',
   LockResolverTransactionNotFound: 'lock_resolver_transaction_not_found',
-  DatabaseDowngradeNotAllowed: 'database_downgrade_not_allowed',
+  TransactionNumberBlockNumberTooLarge: 'transaction_number_block_number_too_large',
+  TransactionNumberTransactionIndexInBlockTooLarge: 'transaction_number_transaction_index_in_block_too_large',
   ValueTimeLockInPendingState: 'value_time_lock_in_pending_state',
   VersionManagerVersionStringNotFound: 'version_manager_version_string_not_found'
 };

--- a/lib/bitcoin/TransactionNumber.ts
+++ b/lib/bitcoin/TransactionNumber.ts
@@ -1,34 +1,68 @@
+import ErrorCode from './ErrorCode';
+import SidetreeError from '../common/SidetreeError';
+
 /**
- * Defines the TransactionNumber as a combination of blockNumber and position within the block
+ * Defines the TransactionNumber as a combination of block number and transaction index within the block.
  */
 export default class TransactionNumber {
 
-  /* We set blockNumber and position to be 32 bits each */
-  private static readonly bitWidth = 32;
+  /**
+   * Maximum allowed transaction index in a block.
+   */
+  private static readonly maxTransactionIndexInBlock = 999999;
 
   /**
-   * Constructs the transaction number given the block number and position of the transaction in the block.
+   * Maximum allowed transaction count in a block.
    */
-  public static construct (blockNumber: number, position: number) {
-    const transactionNumber =
-      blockNumber * (2 ** this.bitWidth) +
-      position;
+  private static readonly maxTransactionCountInBlock = TransactionNumber.maxTransactionIndexInBlock + 1; // 1,000,000
 
+  /**
+   * Constructs the transaction number given the block number and the transaction index in the block.
+   */
+  public static construct (blockNumber: number, transactionIndexInBlock: number) {
+    // NOTE: JavaScript can have 53 bit integer before starting to loose precision: 2 ^ 53 = 9,007,199,254,740,992.
+    // We allocate first 6 digits for transaction index within a block, and rest of the digits for block number.
+
+    if (transactionIndexInBlock > TransactionNumber.maxTransactionIndexInBlock) {
+      throw new SidetreeError(
+        ErrorCode.TransactionNumberTransactionIndexInBlockTooLarge,
+        `Position index ${transactionIndexInBlock} given exceeds max allowed value of ${TransactionNumber.maxTransactionIndexInBlock}`
+      );
+    }
+
+    // Choosing a nice round number as long as it is less than `9007199254`.
+    const maxBlockNumber = 9000000000;
+    if (blockNumber > maxBlockNumber) {
+      throw new SidetreeError(
+        ErrorCode.TransactionNumberBlockNumberTooLarge,
+        `Block number ${blockNumber} given exceeds max allowed value of ${maxBlockNumber}`
+      );
+    }
+
+    const transactionNumber = TransactionNumber.privateConstruct(blockNumber, transactionIndexInBlock);
+    return transactionNumber;
+  }
+
+  /**
+   * Internal construction method that assumes inputs are valid/validated.
+   */
+  private static privateConstruct (blockNumber: number, transactionIndexInBlock: number) {
+    const transactionNumber = blockNumber * TransactionNumber.maxTransactionCountInBlock + transactionIndexInBlock;
     return transactionNumber;
   }
 
   /**
    * Constructs the transaction number of the last possible transaction of the specified block.
    */
-  public static lastTransactionOfBlock (blockHeight: number) {
-    return TransactionNumber.construct(blockHeight + 1, 0) - 1;
+  public static lastTransactionOfBlock (blockNumber: number) {
+    return TransactionNumber.privateConstruct(blockNumber, TransactionNumber.maxTransactionIndexInBlock);
   }
 
   /**
    * Returns the block number component of transactionNumber
    */
   public static getBlockNumber (transactionNumber: number) {
-    const blockNumber = Math.floor(transactionNumber / (2 ** this.bitWidth));
+    const blockNumber = Math.trunc(transactionNumber / TransactionNumber.maxTransactionCountInBlock);
     return blockNumber;
   }
 
@@ -36,7 +70,7 @@ export default class TransactionNumber {
    * Returns the position component of transactionNumber
    */
   public static getPosition (transactionNumber: number) {
-    const mask = 2 ** TransactionNumber.bitWidth - 1;
-    return (transactionNumber & mask);
+    const transactionIndexInBlock = transactionNumber % TransactionNumber.maxTransactionCountInBlock;
+    return transactionIndexInBlock;
   }
 }

--- a/lib/bitcoin/TransactionNumber.ts
+++ b/lib/bitcoin/TransactionNumber.ts
@@ -65,12 +65,4 @@ export default class TransactionNumber {
     const blockNumber = Math.trunc(transactionNumber / TransactionNumber.maxTransactionCountInBlock);
     return blockNumber;
   }
-
-  /**
-   * Returns the position component of transactionNumber
-   */
-  public static getPosition (transactionNumber: number) {
-    const transactionIndexInBlock = transactionNumber % TransactionNumber.maxTransactionCountInBlock;
-    return transactionIndexInBlock;
-  }
 }

--- a/lib/core/Core.ts
+++ b/lib/core/Core.ts
@@ -168,7 +168,7 @@ export default class Core {
       return;
     }
 
-    const expectedDbVersion = '1.0.1';
+    const expectedDbVersion = '1.1.0';
     const savedServiceState = await this.serviceStateStore.get();
     const actualDbVersion = savedServiceState.databaseVersion;
 
@@ -194,6 +194,8 @@ export default class Core {
     await this.transactionStore.clearCollection();
     await this.unresolvableTransactionStore.clearCollection();
 
+    // There was a index change/addition in from v1.0.0 -> v1.0.1 of the DB, this line ensures new indices are created,
+    // but can be optional in the future when v1.0.0 is so old that we don't care about upgrade path from it.
     await this.operationStore.createIndex();
 
     await this.serviceStateStore.put({ databaseVersion: expectedDbVersion });

--- a/lib/core/interfaces/ITransactionSelector.ts
+++ b/lib/core/interfaces/ITransactionSelector.ts
@@ -6,8 +6,8 @@ import TransactionModel from '../../common/models/TransactionModel';
 export default interface ITransactionSelector {
 
   /**
-   * Given an array of transactions in the same block, return the qualified transactions
-   * @param transactions An array of transactions to be throughput limited
+   * Given an array of transactions in the same block, return the qualified transactions.
+   * @param transactions An array of transactions to be throughput limited.
    */
   selectQualifiedTransactions (transactions: TransactionModel[]): Promise<TransactionModel[]>;
 }

--- a/tests/bitcoin/BitcoinClient.spec.ts
+++ b/tests/bitcoin/BitcoinClient.spec.ts
@@ -1419,7 +1419,7 @@ describe('BitcoinClient', async () => {
 
       await JasmineSidetreeErrorValidator.expectSidetreeErrorToBeThrownAsync(() =>
         bitcoinClient['fetchWithRetry']('http://unused_path', { }, true), // true = timeout enabled.
-      ErrorCode.BitcoinClientFetchHttpCodeWithNetworkIssue
+        ErrorCode.BitcoinClientFetchUnexpectedError
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);

--- a/tests/bitcoin/TransactionNumber.spec.ts
+++ b/tests/bitcoin/TransactionNumber.spec.ts
@@ -1,11 +1,44 @@
+import ErrorCode from '../../lib/bitcoin/ErrorCode';
 import TransactionNumber from '../../lib/bitcoin/TransactionNumber';
 
 describe('TransactionNumber', () => {
+  describe('construct()', () => {
+    it('should construct transaction number correctly.', async () => {
+      const transactionNumber = TransactionNumber.construct(123456789, 777);
+      expect(transactionNumber).toEqual(123456789000777);
+    });
 
-  it('should have getPosition() return position correctly given a transaction number.', async () => {
-    const expectedTransactionIndexInBlock = 8;
-    const transactionNumber = TransactionNumber.construct(1000000, expectedTransactionIndexInBlock);
-    const actualTransactionIndexInBlock = TransactionNumber.getPosition(transactionNumber);
-    expect(actualTransactionIndexInBlock).toEqual(expectedTransactionIndexInBlock);
+    it('should throw error if block number exceeded max value.', async () => {
+      expect(() => TransactionNumber.construct(9000000001, 123456)).toThrow(jasmine.objectContaining({
+        code: ErrorCode.TransactionNumberBlockNumberTooLarge
+      }));
+    });
+
+    it('should throw error if transaction index in block exceeded max value.', async () => {
+      expect(() => TransactionNumber.construct(123456789, 1000000)).toThrow(jasmine.objectContaining({
+        code: ErrorCode.TransactionNumberTransactionIndexInBlockTooLarge
+      }));
+    });
+  });
+
+  describe('lastTransactionOfBlock()', () => {
+    it('should return the transaction number of the last possible transaction in the given block.', async () => {
+      const transactionNumber = TransactionNumber.lastTransactionOfBlock(11111111);
+      expect(transactionNumber).toEqual(11111111999999);
+    });
+  });
+
+  describe('getBlockNumber()', () => {
+    it('should return the block number given a transaction number.', async () => {
+      const blockNumber = TransactionNumber.getBlockNumber(11111111000000);
+      expect(blockNumber).toEqual(11111111);
+    });
+  });
+
+  describe('getPosition()', () => {
+    it('should return position correctly given a transaction number.', async () => {
+      const transactionIndexInBlock = TransactionNumber.getPosition(77777777111111);
+      expect(transactionIndexInBlock).toEqual(111111);
+    });
   });
 });

--- a/tests/bitcoin/TransactionNumber.spec.ts
+++ b/tests/bitcoin/TransactionNumber.spec.ts
@@ -34,11 +34,4 @@ describe('TransactionNumber', () => {
       expect(blockNumber).toEqual(11111111);
     });
   });
-
-  describe('getPosition()', () => {
-    it('should return position correctly given a transaction number.', async () => {
-      const transactionIndexInBlock = TransactionNumber.getPosition(77777777111111);
-      expect(transactionIndexInBlock).toEqual(111111);
-    });
-  });
 });

--- a/tests/core/Core.spec.ts
+++ b/tests/core/Core.spec.ts
@@ -201,7 +201,7 @@ describe('Core', async () => {
       const core = new Core(testConfig, testVersionConfig, mockCas);
 
       // Simulate that the saved database version is the same as the expected database version.
-      spyOn(core['serviceStateStore'], 'get').and.returnValue(Promise.resolve({ databaseVersion: '1.0.1' }));
+      spyOn(core['serviceStateStore'], 'get').and.returnValue(Promise.resolve({ databaseVersion: '1.1.0' }));
 
       const serviceStateStorePutSpy = spyOn(core['serviceStateStore'], 'put');
       await (core as any).upgradeDatabaseIfNeeded();
@@ -229,7 +229,7 @@ describe('Core', async () => {
       expect(unresolvableTransactionStoreClearCollectionSpy).toHaveBeenCalled();
       expect(transactionStoreClearCollectionSpy).toHaveBeenCalled();
       expect(operationStoreCreateIndexSpy).toHaveBeenCalled();
-      expect(serviceStateStorePutSpy).toHaveBeenCalledWith({ databaseVersion: '1.0.1' });
+      expect(serviceStateStorePutSpy).toHaveBeenCalledWith({ databaseVersion: '1.1.0' });
     });
 
     it('should throw if attempting to run older code on newer DB.', async () => {


### PR DESCRIPTION
This was discovered in https://github.com/decentralized-identity/ion/issues/240

As a result, rewrote how transaction number is constructed to produce a smaller integer. Also took the opportunity to make the transaction number much more human-friendly also, the current transaction number format had been annoying me for a long time.

Specifically, the current transaction number is simply a large ugly looking number that doesn't make any sense to a human. It would be much easier to make sense of (thus debug), now that a transaction on index position 500 in block 777777 is 777777000500, as opposed to 3340526778581492. Notice the number is smaller AND easier to make sense of.

Also, due to this internal transaction number scheme change, both core and blockchain service will be required to be upgraded to the same build at the same time, a bit painful, but isn't worth more engineering time IMO to mitigate this inconvenience.