### PR TITLE
Specify resolution result Content-Type

### DIFF
--- a/docs/api/content.md
+++ b/docs/api/content.md
@@ -14,6 +14,8 @@ Sidetree defines `published`, `updateCommitment`, and `recoveryCommitment` metho
    - `updateCommitment` is the commitment for the next update operation as defined in [commitment schemes](https://identity.foundation/sidetree/spec/#commitment-schemes).
    - `recoveryCommitment` is the commitment for the next recover or deactivate operation as defined in [commitment schemes](https://identity.foundation/sidetree/spec/#commitment-schemes).
 
+The DID Resolution Result response ****MUST**** contain a `Content-Type` HTTP header with value `application/ld+json;profile="https://w3id.org/did-resolution"`.
+
 ::: example
 ```json
 {


### PR DESCRIPTION
This adds a requirement for a DID Resolution Result HTTP response to set a Content-Type header to indicate that it is a DID Resolution Result, as specified in DID Resolution:
- https://w3c-ccg.github.io/did-resolution/#did-resolution-result
- https://w3c-ccg.github.io/did-resolution/#bindings-https

Setting this Content-Type header is proposed in a PR to the ION implementation: https://github.com/decentralized-identity/ion/pull/244