### PR TITLE
fix(ref-imp): allow setting controller property

### DIFF
--- a/lib/core/versions/latest/DocumentComposer.ts
+++ b/lib/core/versions/latest/DocumentComposer.ts
@@ -40,7 +40,7 @@ export default class DocumentComposer {
         const id = '#' + publicKey.id;
         const didDocumentPublicKey = {
           id: id,
-          controller: did.isShortForm ? did.shortForm : did.longForm,
+          controller: publicKey.controller || (did.isShortForm ? did.shortForm : did.longForm),
           type: publicKey.type,
           publicKeyJwk: publicKey.publicKeyJwk
         };
@@ -218,7 +218,7 @@ export default class DocumentComposer {
 
     const publicKeyIdSet: Set<string> = new Set();
     for (const publicKey of publicKeys) {
-      const allowedProperties = new Set(['id', 'type', 'purposes', 'publicKeyJwk']);
+      const allowedProperties = new Set(['id', 'type', 'purposes', 'publicKeyJwk', 'controller']);
       for (const property in publicKey) {
         if (!allowedProperties.has(property)) {
           throw new SidetreeError(ErrorCode.DocumentComposerPublicKeyUnknownProperty, `Unexpected property, ${property}, in publicKey.`);

--- a/lib/core/versions/latest/models/PublicKeyModel.ts
+++ b/lib/core/versions/latest/models/PublicKeyModel.ts
@@ -8,4 +8,5 @@ export default interface PublicKeyModel {
   type: string;
   publicKeyJwk: any;
   purposes?: PublicKeyPurpose[];
+  controller?: string;
 }


### PR DESCRIPTION
Allow setting the controller property of a public key entry (verification method object), as described here: https://identity.foundation/sidetree/spec/v1.0.0/#add-public-keys