### PR TITLE
feat(ref-imp): added built-in polling for Bitcoin Core readiness

### DIFF
--- a/lib/bitcoin/BitcoinClient.ts
+++ b/lib/bitcoin/BitcoinClient.ts
@@ -841,17 +841,17 @@ export default class BitcoinClient {
 
   /**
    *
-   * @param request The request for the rpc call
+   * @param request The request for the RPC call
    * @param timeout Should timeout or not
-   * @param isWalletRpc Is wallet rpc or not. Should pass in true if the rpc call is called on specific wallet
+   * @param isWalletRpc Must set to `true` if the RPC is wallet-specific; `false` otherwise.
    */
   private async rpcCall (request: any, timeout: boolean, isWalletRpc: boolean): Promise<any> {
-    // append some standard jrpc parameters
+    // Append some standard RPC parameters.
     request.jsonrpc = '1.0';
     request.id = Math.round(Math.random() * Number.MAX_SAFE_INTEGER).toString(32);
 
     const requestString = JSON.stringify(request);
-    Logger.info(`Sending jRPC request: id: ${request.id}, method: ${request.method}`);
+    Logger.info(`Sending jRPC request: id: ${request.id}, method: ${request.method}, request: ${requestString}`);
 
     const requestOptions: RequestInit = {
       body: requestString,

--- a/lib/bitcoin/BitcoinClient.ts
+++ b/lib/bitcoin/BitcoinClient.ts
@@ -96,7 +96,7 @@ export default class BitcoinClient {
 
         Logger.info(LogColor.lightBlue(`Bitcoin sync progress: block height ${LogColor.green(blockHeight)}, sync-ed: ${LogColor.green(syncedBlockHeight)}`));
 
-        if (syncedBlockHeight === blockHeight) {
+        if (blockHeight !== 0 && syncedBlockHeight === blockHeight) {
           Logger.info(LogColor.lightBlue('Bitcoin Core fully synchronized'));
           return;
         }

--- a/lib/bitcoin/models/BitcoinBlockModel.ts
+++ b/lib/bitcoin/models/BitcoinBlockModel.ts
@@ -1,7 +1,7 @@
 import BitcoinTransactionModel from './BitcoinTransactionModel';
 
 /**
- * Encapsulates the block data returned by the bitcoin service.
+ * Encapsulates the block data returned by the bitcoin service or block parsed directly from file.
  */
 export default interface BitcoinBlockModel {
   hash: string;

--- a/lib/ipfs/Ipfs.ts
+++ b/lib/ipfs/Ipfs.ts
@@ -40,7 +40,7 @@ export default class Ipfs implements ICas {
     // Binary content of second part.
     // --ABoundaryString--
     const beginBoundary = Buffer.from(`--${multipartBoundaryString}\n`);
-    const contentDisposition = Buffer.from(`Content-Disposition: form-data;\n`) // Required since IPFS v0.11
+    const contentDisposition = Buffer.from(`Content-Disposition: form-data;\n`); // Required since IPFS v0.11
     const firstPartContentType = Buffer.from(`Content-Type: application/octet-stream\n\n`);
     const endBoundary = Buffer.from(`\n--${multipartBoundaryString}--`);
     const requestBody = Buffer.concat([beginBoundary, contentDisposition, firstPartContentType, content, endBoundary]);

--- a/tests/bitcoin/BitcoinClient.spec.ts
+++ b/tests/bitcoin/BitcoinClient.spec.ts
@@ -149,6 +149,7 @@ describe('BitcoinClient', async () => {
 
   describe('initialize', () => {
     it('should import key if the wallet does not exist', async () => {
+      const waitUntilBitcoinCoreIsReadySpy = spyOn(bitcoinClient as any, 'waitUntilBitcoinCoreIsReady').and.returnValue(Promise.resolve(true));
       const walletExistsSpy = spyOn(bitcoinClient as any, 'isAddressAddedToWallet').and.returnValue(Promise.resolve(false));
       const publicKeyHex = privateKeyFromBitcoinClient.toPublicKey().toBuffer().toString('hex');
 
@@ -163,6 +164,7 @@ describe('BitcoinClient', async () => {
       const loadWalletSpy = spyOn(bitcoinClient as any, 'loadWallet');
 
       await bitcoinClient.initialize();
+      expect(waitUntilBitcoinCoreIsReadySpy).toHaveBeenCalled();
       expect(walletExistsSpy).toHaveBeenCalled();
       expect(importSpy).toHaveBeenCalled();
       expect(createWalletSpy).toHaveBeenCalled();
@@ -170,6 +172,7 @@ describe('BitcoinClient', async () => {
     });
 
     it('should not import key if the wallet already exist', async () => {
+      const waitUntilBitcoinCoreIsReadySpy = spyOn(bitcoinClient as any, 'waitUntilBitcoinCoreIsReady').and.returnValue(Promise.resolve(true));
       const walletExistsSpy = spyOn(bitcoinClient as any, 'isAddressAddedToWallet').and.returnValue(Promise.resolve(true));
 
       const importSpy = spyOn(bitcoinClient as any, 'addWatchOnlyAddressToWallet');
@@ -177,10 +180,21 @@ describe('BitcoinClient', async () => {
       const loadWalletSpy = spyOn(bitcoinClient as any, 'loadWallet');
 
       await bitcoinClient.initialize();
+      expect(waitUntilBitcoinCoreIsReadySpy).toHaveBeenCalled();
       expect(walletExistsSpy).toHaveBeenCalled();
       expect(importSpy).not.toHaveBeenCalled();
       expect(createWalletSpy).toHaveBeenCalled();
       expect(loadWalletSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('waitUntilBitcoinCoreIsReady', () => {
+    it('should keep checking status until Bitcoin Core is fully sync-ed', async () => {
+
+    });
+
+    it('should keep checking status if error is encountered', async () => {
+
     });
   });
 

--- a/tests/bitcoin/BitcoinClient.spec.ts
+++ b/tests/bitcoin/BitcoinClient.spec.ts
@@ -190,11 +190,34 @@ describe('BitcoinClient', async () => {
 
   describe('waitUntilBitcoinCoreIsReady', () => {
     it('should keep checking status until Bitcoin Core is fully sync-ed', async () => {
+      const firstBitcoinCoreState = {
+        headers: 100,
+        blocks: 20 // simulates 20% synchronization
+      };
+      const secondBitcoinCoreState = {
+        headers: 100,
+        blocks: 100 // simulates 100% synchronization
+      };
+      const rpcSpy = spyOn(bitcoinClient as any, 'rpcCall').and.returnValues(firstBitcoinCoreState, secondBitcoinCoreState);
 
+      const pollingWindowInSeconds = 0; // skip any waiting in unit tests
+      await bitcoinClient['waitUntilBitcoinCoreIsReady'](pollingWindowInSeconds);
+
+      expect(rpcSpy).toHaveBeenCalledTimes(2);
     });
 
     it('should keep checking status if error is encountered', async () => {
+      const firstBitcoinCoreState = undefined; // forcing an error to be thrown internally
+      const secondBitcoinCoreState = {
+        headers: 100,
+        blocks: 100 // simulates 100% synchronization
+      };
+      const rpcSpy = spyOn(bitcoinClient as any, 'rpcCall').and.returnValues(firstBitcoinCoreState, secondBitcoinCoreState);
 
+      const pollingWindowInSeconds = 0; // skip any waiting in unit tests
+      await bitcoinClient['waitUntilBitcoinCoreIsReady'](pollingWindowInSeconds);
+
+      expect(rpcSpy).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/tests/ipfs/Ipfs.spec.ts
+++ b/tests/ipfs/Ipfs.spec.ts
@@ -1,4 +1,3 @@
-import nodeFetch from 'node-fetch';
 import FetchResultCode from '../../lib/common/enums/FetchResultCode';
 import ICas from '../../lib/core/interfaces/ICas';
 import Ipfs from '../../lib/ipfs/Ipfs';
@@ -8,6 +7,7 @@ import ReadableStream from '../../lib/common/ReadableStream';
 import SharedErrorCode from '../../lib/common/SharedErrorCode';
 import SidetreeError from '../../lib/common/SidetreeError';
 import Timeout from '../../lib/ipfs/Util/Timeout';
+import nodeFetch from 'node-fetch';
 
 describe('Ipfs', async () => {
   const config = require('../json/config-test.json');
@@ -19,7 +19,7 @@ describe('Ipfs', async () => {
     try {
       const response = await nodeFetch(ipfsVersionUrl, { method: 'POST' });
 
-      if(response.status === 200) {
+      if (response.status === 200) {
         networkAvailable = true;
       }
     } catch {


### PR DESCRIPTION
This has been an ask from many people for a while and finally got around to implement it:

- https://github.com/decentralized-identity/sidetree/issues/692
- https://github.com/decentralized-identity/ion/issues/150

In summary, up until now, the Sidetree Bitcoin service expects Bitcoin Core to be in a fully sync-ed and ready state when it starts up, it exits if Bitcoin Core isn't ready to serve requests.

This behavior had been fine for deployment frameworks like kubernetes which restarts the service automatically. But painful for manual setups. This will also help simplify dockerization, because we can now fire-and-forget after starting the container.

Also used this opportunity to add better logging and more documentation on the "fast initialization" code.