### PR TITLE
Added DB initialization retry on startup for better docker support

### DIFF
--- a/lib/bitcoin/BitcoinProcessor.ts
+++ b/lib/bitcoin/BitcoinProcessor.ts
@@ -162,11 +162,12 @@ export default class BitcoinProcessor {
     Logger.initialize(customLogger);
     EventEmitter.initialize(customEventEmitter);
 
+    await this.bitcoinClient.initialize();
+
     await this.versionManager.initialize(versionModels, this.config, this.blockMetadataStore);
     await this.serviceStateStore.initialize();
     await this.blockMetadataStore.initialize();
     await this.transactionStore.initialize();
-    await this.bitcoinClient.initialize();
     await this.mongoDbLockTransactionStore.initialize();
 
     await this.upgradeDatabaseIfNeeded();

--- a/lib/core/Core.ts
+++ b/lib/core/Core.ts
@@ -90,13 +90,8 @@ export default class Core {
     Logger.initialize(customLogger);
     EventEmitter.initialize(customEventEmitter);
 
-    // DB initializations.
-    await this.serviceStateStore.initialize();
-    await this.transactionStore.initialize();
-    await this.unresolvableTransactionStore.initialize();
-    await this.operationStore.initialize();
-    await this.confirmationStore.initialize();
-    await this.upgradeDatabaseIfNeeded();
+    // DB initialization.
+    await this.initializeDataStores(this.config.observingIntervalInSeconds);
 
     await this.versionManager.initialize(
       this.blockchain,
@@ -126,6 +121,30 @@ export default class Core {
     this.downloadManager.start();
 
     await this.monitor.initialize();
+  }
+
+  /**
+   * Attempts to initialize data stores until success.
+   * @param retryWaitTimeOnFailureInSeconds Time to wait if initialization failed.
+   */
+  private async initializeDataStores (retryWaitTimeOnFailureInSeconds: number): Promise<void> {
+    // Keep retrying until success to handle the case when DB is not yet available upon initialization, e.g. docker-compose startup.
+    while (true) {
+      try {
+        await this.serviceStateStore.initialize();
+        await this.transactionStore.initialize();
+        await this.unresolvableTransactionStore.initialize();
+        await this.operationStore.initialize();
+        await this.confirmationStore.initialize();
+        await this.upgradeDatabaseIfNeeded();
+        return;
+      } catch (error) {
+        Logger.info(LogColor.yellow(`Unable to initialize data stores: ${error}.`));
+      }
+
+      Logger.info(`Retry data store initialization after ${retryWaitTimeOnFailureInSeconds} seconds...`);
+      await new Promise(resolve => setTimeout(resolve, retryWaitTimeOnFailureInSeconds * 1000));
+    }
   }
 
   /**

--- a/lib/core/Core.ts
+++ b/lib/core/Core.ts
@@ -90,7 +90,7 @@ export default class Core {
     Logger.initialize(customLogger);
     EventEmitter.initialize(customEventEmitter);
 
-    // DB initialization.
+    // DB initializations.
     await this.initializeDataStores(this.config.observingIntervalInSeconds);
 
     await this.versionManager.initialize(
@@ -128,7 +128,7 @@ export default class Core {
    * @param retryWaitTimeOnFailureInSeconds Time to wait if initialization failed.
    */
   private async initializeDataStores (retryWaitTimeOnFailureInSeconds: number): Promise<void> {
-    // Keep retrying until success to handle the case when DB is not yet available upon initialization, e.g. docker-compose startup.
+    // Keep retrying until success to handle the case when DB is not yet available upon initialization, e.g. better docker-compose startup support.
     while (true) {
       try {
         await this.serviceStateStore.initialize();


### PR DESCRIPTION
Core service can fail on startup during DB initialization in `docker-compose` when mongoDB is also being spun up and not ready to serve requests. This PR fixes that.