### PR TITLE
Handle HTTP 503 statuses returned from blockchain service

### DIFF
--- a/lib/core/Blockchain.ts
+++ b/lib/core/Blockchain.ts
@@ -214,6 +214,10 @@ export default class Blockchain implements IBlockchain {
     if (response.status === HttpStatus.NOT_FOUND) {
       return undefined;
     }
+
+    // Treat a HTTP 503 from the blockchain service as a non-error and
+    // return `undefined` such that a minimum-size batch will be
+    // written instead of the batch write being skipped
     if (response.status === HttpStatus.SERVICE_UNAVAILABLE) {
       return undefined;
     }

--- a/lib/core/Blockchain.ts
+++ b/lib/core/Blockchain.ts
@@ -201,6 +201,9 @@ export default class Blockchain implements IBlockchain {
     if (response.status === HttpStatus.NOT_FOUND) {
       return undefined;
     }
+    if (response.status === HttpStatus.SERVICE_UNAVAILABLE) {
+      return undefined;
+    }
 
     if (response.status !== HttpStatus.OK) {
       throw new SidetreeError(CoreErrorCode.BlockchainGetLockResponseNotOk, `Response: ${responseBodyString}`);
@@ -212,6 +215,9 @@ export default class Blockchain implements IBlockchain {
   public async getWriterValueTimeLock (): Promise<ValueTimeLockModel | undefined> {
     const response = await this.fetch(this.writerLockUri);
     if (response.status === HttpStatus.NOT_FOUND) {
+      return undefined;
+    }
+    if (response.status === HttpStatus.SERVICE_UNAVAILABLE) {
       return undefined;
     }
 

--- a/lib/core/Blockchain.ts
+++ b/lib/core/Blockchain.ts
@@ -201,9 +201,6 @@ export default class Blockchain implements IBlockchain {
     if (response.status === HttpStatus.NOT_FOUND) {
       return undefined;
     }
-    if (response.status === HttpStatus.SERVICE_UNAVAILABLE) {
-      return undefined;
-    }
 
     if (response.status !== HttpStatus.OK) {
       throw new SidetreeError(CoreErrorCode.BlockchainGetLockResponseNotOk, `Response: ${responseBodyString}`);

--- a/tests/core/Blockchain.spec.ts
+++ b/tests/core/Blockchain.spec.ts
@@ -380,23 +380,6 @@ describe('Blockchain', async () => {
       done();
     });
 
-    it('should return undefined if service-unavailable is returned by the network call.', async (done) => {
-      const blockchainClient = new Blockchain('unused');
-
-      const mockFetchResponse = {
-        status: 503,
-        body: ''
-      };
-
-      spyOn(blockchainClient as any, 'fetch').and.returnValue(Promise.resolve(mockFetchResponse));
-      spyOn(ReadableStream, 'readAll').and.returnValue(Promise.resolve(Buffer.from(mockFetchResponse.body)));
-
-      const actual = await blockchainClient.getValueTimeLock('non-existent-identifier');
-
-      expect(actual).not.toBeDefined();
-      done();
-    });
-
     it('should return undefined if not-found is returned by the network call.', async (done) => {
       const blockchainClient = new Blockchain('unused');
 

--- a/tests/core/Blockchain.spec.ts
+++ b/tests/core/Blockchain.spec.ts
@@ -380,6 +380,23 @@ describe('Blockchain', async () => {
       done();
     });
 
+    it('should return undefined if service-unavailable is returned by the network call.', async (done) => {
+      const blockchainClient = new Blockchain('unused');
+
+      const mockFetchResponse = {
+        status: 503,
+        body: ''
+      };
+
+      spyOn(blockchainClient as any, 'fetch').and.returnValue(Promise.resolve(mockFetchResponse));
+      spyOn(ReadableStream, 'readAll').and.returnValue(Promise.resolve(Buffer.from(mockFetchResponse.body)));
+
+      const actual = await blockchainClient.getValueTimeLock('non-existent-identifier');
+
+      expect(actual).not.toBeDefined();
+      done();
+    });
+
     it('should return undefined if not-found is returned by the network call.', async (done) => {
       const blockchainClient = new Blockchain('unused');
 
@@ -451,6 +468,23 @@ describe('Blockchain', async () => {
       const mockFetchResponse = {
         status: 404,
         body: '{"code": "some error code"}'
+      };
+
+      spyOn(blockchainClient as any, 'fetch').and.returnValue(Promise.resolve(mockFetchResponse));
+      spyOn(ReadableStream, 'readAll').and.returnValue(Promise.resolve(Buffer.from(mockFetchResponse.body)));
+
+      const actual = await blockchainClient.getWriterValueTimeLock();
+
+      expect(actual).not.toBeDefined();
+      done();
+    });
+
+    it('should return undefined if service-unavailable is returned by the network call.', async (done) => {
+      const blockchainClient = new Blockchain('unused');
+
+      const mockFetchResponse = {
+        status: 503,
+        body: ''
       };
 
       spyOn(blockchainClient as any, 'fetch').and.returnValue(Promise.resolve(mockFetchResponse));


### PR DESCRIPTION
Change to not throw an error if the underlying blockchain service is unavailable when retrieving lock objects.