### PR TITLE
Add exports for blockchain service class and interfaces

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@
 
 import ISidetreeBitcoinConfig from './bitcoin/IBitcoinConfig';
 import ISidetreeBitcoinWallet from './bitcoin/interfaces/IBitcoinWallet';
+import ISidetreeBlockchain from './core/interfaces/IBlockchain';
 import ISidetreeCas from './core/interfaces/ICas';
 import ISidetreeEventEmitter from './common/interfaces/IEventEmitter';
 import ISidetreeLogger from './common/interfaces/ILogger';
@@ -9,12 +10,17 @@ import SidetreeBitcoinEventCode from './bitcoin/EventCode';
 import SidetreeBitcoinMonitor from './bitcoin/Monitor';
 import SidetreeBitcoinProcessor from './bitcoin/BitcoinProcessor';
 import SidetreeBitcoinVersionModel from './bitcoin/models/BitcoinVersionModel';
+import SidetreeBlockchain from './core/Blockchain';
+import SidetreeBlockchainTimeModel from './core/models/BlockchainTimeModel';
 import SidetreeConfig from './core/models/Config';
 import SidetreeCore from './core/Core';
 import SidetreeEventCode from './core/EventCode';
 import SidetreeMonitor from './core/Monitor';
 import SidetreeResponse from './common/Response';
 import SidetreeResponseModel from './common/models/ResponseModel';
+import SidetreeServiceVersionModel from './common/models/ServiceVersionModel';
+import SidetreeTransactionModel from './common/models/TransactionModel';
+import SidetreeValueTimeLockModel from './common/models/ValueTimeLockModel';
 import SidetreeVersionModel from './core/models/VersionModel';
 
 // Core service exports.
@@ -33,14 +39,20 @@ export {
 export {
   ISidetreeBitcoinConfig,
   ISidetreeBitcoinWallet,
+  ISidetreeBlockchain,
   SidetreeBitcoinEventCode,
   SidetreeBitcoinMonitor,
   SidetreeBitcoinProcessor,
-  SidetreeBitcoinVersionModel
+  SidetreeBitcoinVersionModel,
+  SidetreeBlockchain,
+  SidetreeBlockchainTimeModel
 };
 
 // Common exports.
 export {
   ISidetreeEventEmitter,
-  ISidetreeLogger
+  ISidetreeLogger,
+  SidetreeServiceVersionModel,
+  SidetreeTransactionModel,
+  SidetreeValueTimeLockModel
 };


### PR DESCRIPTION
Follow-up to https://github.com/decentralized-identity/sidetree/pull/1203

This PR further facilitates the injection of the blockchain dependency by _exporting_ the interfaces from which it is composed